### PR TITLE
Golfing

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -42,14 +42,14 @@ function prefetcher(url) {
  * @param {Object} options - Configuration options for quicklink
  * @param {Array} options.urls - Array of URLs to prefetch (override)
  * @param {Object} options.el - DOM element to prefetch in-viewport links of
- * @param {string} options.priority - Attempt to fetch with higher priority (low or high)
+ * @param {Boolean} options.priority - Attempt higher priority fetch (low or high)
  * @param {Number} options.timeout - Timeout after which prefetching will occur
  * @param {function} options.timeoutFn - Custom timeout function
  */
 export default function (options) {
   options = Object.assign({
-    priority: 'low',
     timeout: 2e3,
+    priority: false,
     timeoutFn: requestIdleCallback,
     el: document,
   }, options);

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -59,17 +59,15 @@ export default function (options) {
     }
 
     // If not, find all links and use IntersectionObserver.
-    const urls = Array.from(options.el.querySelectorAll('a'), link => {
+    Array.from(options.el.querySelectorAll('a'), link => {
     	observer.observe(link);
-    	return link.href;
-    });
 
-    // Generate loader functions for each link
-    urls.forEach(url => {
-      loaderFunctions.set(url, () => {
-        loaderFunctions.delete(url);
-        prefetch(url, options.priority);
-      });
+	    // Generate loader functions for each link
+	    const uri = link.href;
+    	loaderFunctions.set(uri, () => {
+    		loaderFunctions.delete(uri);
+    		prefetch(uri, options.priority);
+    	});
     });
   }, {timeout: options.timeout});
 }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -44,15 +44,12 @@ const observer = new IntersectionObserver(entries => {
  * @param {function} options.timeoutFn - Custom timeout function
  */
 export default function (options) {
-  options = {
-    ...{
-      priority: 'low',
-      timeout: 2000,
-      timeoutFn: requestIdleCallback,
-      el: document,
-    },
-    ...options,
-  };
+  options = Object.assign({
+    priority: 'low',
+    timeout: 2e3,
+    timeoutFn: requestIdleCallback,
+    el: document,
+  }, options);
 
   options.timeoutFn(() => {
     // If URLs are given, prefetch them.

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -30,7 +30,7 @@ const observer = new IntersectionObserver(entries => {
 
 function prefetcher(url) {
 	toPrefetch.delete(url);
-	return prefetch(url, observer.priority);
+	prefetch(url, observer.priority);
 }
 
 /**

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -23,10 +23,8 @@ const observer = new IntersectionObserver(entries => {
       .filter(entry => entry.isIntersecting)
       .forEach(entry => {
         const url = entry.target.href;
-        if (!loaderFunctions.has(url)) {
-          return;
-        }
-        loaderFunctions.get(url).call(null);
+        const fn = loaderFunctions.get(url);
+        if (fn) fn.call(null);
       });
 });
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -62,9 +62,10 @@ export default function (options) {
     }
 
     // If not, find all links and use IntersectionObserver.
-    const linkTags = Array.from(options.el.querySelectorAll('a'));
-    linkTags.forEach(link => observer.observe(link));
-    const urls = linkTags.map(link => link.href);
+    const urls = Array.from(options.el.querySelectorAll('a'), link => {
+    	observer.observe(link);
+    	return link.href;
+    });
 
     // Generate loader functions for each link
     urls.forEach(url => {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -19,13 +19,13 @@ import requestIdleCallback from './request-idle-callback.mjs';
 
 const loaderFunctions = new Map();
 const observer = new IntersectionObserver(entries => {
-  entries
-      .filter(entry => entry.isIntersecting)
-      .forEach(entry => {
-        const url = entry.target.href;
-        const fn = loaderFunctions.get(url);
-        if (fn) fn.call(null);
-      });
+  entries.forEach(entry => {
+  	if (entry.isIntersecting) {
+      const url = entry.target.href;
+      const fn = loaderFunctions.get(url);
+      if (fn) fn.call(null);
+  	}
+  });
 });
 
 /**

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -110,8 +110,14 @@ function prefetcher(url, isPriority) {
   }
 
   if ('connection' in navigator) {
-    // Don't prefetch if the user is on 2G or if Save-Data is enabled...
-    if ((navigator.connection.effectiveType || '').includes('2g') || navigator.connection.saveData) return;
+    // Don't prefetch if the user is on 2G...
+    if ((navigator.connection.effectiveType || '').includes('2g')) {
+      return;
+    }
+    // Don't prefetch ifSave-Data is enabled...
+    if (navigator.connection.saveData) {
+      return;
+    }
   }
 
   // Wanna do something on catch()?

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -45,11 +45,6 @@ function support(feature) {
  */
 function linkPrefetchStrategy(url) {
   return new Promise((resolve, reject) => {
-    if (typeof document === `undefined`) {
-      reject();
-      return;
-    }
-
     const link = document.createElement(`link`);
     link.rel = `prefetch`;
     link.href = url;

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -51,8 +51,8 @@ function linkPrefetchStrategy(url) {
     }
 
     const link = document.createElement(`link`);
-    link.setAttribute(`rel`, `prefetch`);
-    link.setAttribute(`href`, url);
+    link.rel = `prefetch`;
+    link.href = url;
 
     link.onload = resolve;
     link.onerror = reject;

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -28,8 +28,8 @@ function support(feature) {
   if (typeof document === `undefined`) {
     return false;
   }
-  const fakeLink = document.createElement(`link`);
   try {
+    const fakeLink = document.createElement(`link`);
     if (fakeLink.relList && typeof fakeLink.relList.supports === `function`) {
       return fakeLink.relList.supports(feature);
     }
@@ -76,14 +76,10 @@ function xhrPrefetchStrategy(url) {
     req.withCredentials = true;
 
     req.onload = () => {
-      if (req.status === 200) {
-        resolve();
-      } else {
-        reject();
-      }
+      (req.status === 200) ? resolve() : reject();
     };
 
-    req.send(null);
+    req.send();
   });
 };
 
@@ -98,14 +94,11 @@ function highPriFetchStrategy(url) {
   // fetches. May have to sniff file-extension to provide
   // valid 'as' values. In the future, we may be able to
   // use Priority Hints here.
-  if (self.fetch === undefined) {
-    return xhrPrefetchStrategy(url);
-  } else {
-    // As of 2018, fetch() is high-priority in Chrome
-    // and medium-priority in Safari.
-    return fetch(url, {credentials: `include`});
-  }
-};
+  //
+  // As of 2018, fetch() is high-priority in Chrome
+  // and medium-priority in Safari.
+  return self.fetch == null ? xhrPrefetchStrategy(url) : fetch(url, {credentials: `include`});
+}
 
 const supportedPrefetchStrategy = support(`prefetch`)
   ? linkPrefetchStrategy

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -89,7 +89,9 @@ function highPriFetchStrategy(url) {
   //
   // As of 2018, fetch() is high-priority in Chrome
   // and medium-priority in Safari.
-  return self.fetch == null ? xhrPrefetchStrategy(url) : fetch(url, {credentials: `include`});
+  return self.fetch == null
+    ? xhrPrefetchStrategy(url)
+    : fetch(url, {credentials: `include`});
 }
 
 const supportedPrefetchStrategy = support(`prefetch`)

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -57,10 +57,7 @@ function linkPrefetchStrategy(url) {
     link.onload = resolve;
     link.onerror = reject;
 
-    const parentElement =
-      document.getElementsByTagName(`head`)[0] ||
-      document.getElementsByName(`script`)[0].parentNode;
-    parentElement.appendChild(link);
+    (document.head || document.querySelector(`script`.parentNode)).appendChild(link);
   });
 };
 

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -116,14 +116,8 @@ function prefetcher(url, isPriority) {
   }
 
   if ('connection' in navigator) {
-    // Don't prefetch if the user is on 2G..
-    if ((navigator.connection.effectiveType || '').includes('2g')) {
-      return;
-    }
-    // Don't prefetch if Save-Data is enabled..
-    if (navigator.connection.saveData) {
-      return;
-    }
+    // Don't prefetch if the user is on 2G or if Save-Data is enabled...
+    if ((navigator.connection.effectiveType || '').includes('2g') || navigator.connection.saveData) return;
   }
 
   // Wanna do something on catch()?

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -113,11 +113,11 @@ const supportedPrefetchStrategy = support(`prefetch`)
 
 /**
  * Prefetch a given URL with an optional preferred fetch priority
- * @param {string} url - the URL to fetch
- * @param {string} priority - preferred fetch priority (`low` or `high`)
+ * @param {String} url - the URL to fetch
+ * @param {Boolean} isPriority - if is "high" priority
  * @return {Object} a Promise
  */
-async function prefetcher(url, priority) {
+async function prefetcher(url, isPriority) {
   if (preFetched[url]) {
     return;
   }
@@ -134,11 +134,7 @@ async function prefetcher(url, priority) {
   }
 
   try {
-    if (priority && priority === `high`) {
-      await highPriFetchStrategy(url);
-    } else {
-      await supportedPrefetchStrategy(url);
-    };
+    await (isPriority ? highPriFetchStrategy : supportedPrefetchStrategy)(url);
     preFetched[url] = true;
   } catch (e) {
     // Wanna do something?

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -110,7 +110,7 @@ const supportedPrefetchStrategy = support(`prefetch`)
  * @param {Boolean} isPriority - if is "high" priority
  * @return {Object} a Promise
  */
-async function prefetcher(url, isPriority) {
+function prefetcher(url, isPriority) {
   if (preFetched[url]) {
     return;
   }
@@ -126,12 +126,10 @@ async function prefetcher(url, isPriority) {
     }
   }
 
-  try {
-    await (isPriority ? highPriFetchStrategy : supportedPrefetchStrategy)(url);
+  // Wanna do something on catch()?
+  return (isPriority ? highPriFetchStrategy : supportedPrefetchStrategy)(url).then(() => {
     preFetched[url] = true;
-  } catch (e) {
-    // Wanna do something?
-  }
+  });
 };
 
 export default prefetcher;

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -114,7 +114,7 @@ function prefetcher(url, isPriority) {
     if ((navigator.connection.effectiveType || '').includes('2g')) {
       return;
     }
-    // Don't prefetch ifSave-Data is enabled...
+    // Don't prefetch if Save-Data is enabled...
     if (navigator.connection.saveData) {
       return;
     }


### PR DESCRIPTION
Sorry for the long-ish PR, but I wanted to break apart each step to document its savings as well make it easier to discuss/revert individual changes. If this is to be accepted, I'd recommend squashing.

> Also, the spacing is a mess 🙈 The `src/.editorconfig` looks to be misconfigured or in the wrong place & I didn't want to adjust it as it'd add PR noise, making the 🏌️hard to see.

The core functionality is preserved at **735 B (gz) / 601 B (br)** – down from **902 B (gz) / 747 B (br)**. It's possible to get it down to `717 gz / 594 br` by inlining the `options` defaults, but that may not read as well 😄 

There _is_ 1 breaking change (which, of course, I can revert): The `priority` option is now a Boolean. Not only did this save ~30 bytes, but IMO it makes more sense since the only options were "high" vs "low". In this format, `options.priority=true` is "high" priority.

The other big wins came from:

* turning the `AsyncFunction` into a regular function that returned the Promise
* dropping `link.setAttribute`s in favor of using `link[key]` directly
* using `document.head` and `document.querySelector` 