### PR TITLE
Fix wrong operator precedence in network-idle.js

### DIFF
--- a/demos/network-idle.js
+++ b/demos/network-idle.js
@@ -25,8 +25,8 @@ navigator.serviceWorker.getRegistration()
 function networkIdleCallback(fn, options = {timeout: 0}) {
   // Call the function immediately if required features are absent
   if (
-    !'MessageChannel' in window ||
-    !'serviceWorker' in navigator ||
+    !('MessageChannel' in window) ||
+    !('serviceWorker' in navigator) ||
     !navigator.serviceWorker.controller
   ) {
     DOMContentLoad.then(() => fn({didTimeout: false}));


### PR DESCRIPTION
Hi team,

I noticed two alerts flagged by [LGTM.com](https://lgtm.com/projects/g/GoogleChromeLabs/quicklink/alerts) on lines 28-29 of `network-idle.js`: the negation operator `!` binds more tightly than `in`. As a result, JavaScript will convert the string `'MessageChannel'` to a boolean (empty string is converted to `true`), before negating it and therefore checking whether `false` is a member of `window`. I imagine that's not what was intended here. Some more info: https://lgtm.com/rules/9980081/

This PR fixes both alerts — the last two in this repo :slightly_smiling_face:! If you like, you can enable LGTM's automated code review for pull requests to make sure that alerts like these (and more serious security issues) never get (re)introduced. For example, the AMPHTML project uses that to keep their codebase clean: https://github.com/ampproject/amphtml/pull/13060

Full disclosure: I'm part of the team that's responsible for LGTM. Let me know if you have any questions or comments!