### PR TITLE
feat(restrict to same origins, add ignores)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,20 @@ quicklink({
 });
 ```
 
+**Allow all origins**
+
+Enables all cross-origin requests to be made.
+
+> **Note:** You may run into [CORB](https://chromium.googlesource.com/chromium/src/+/master/services/network/cross_origin_read_blocking_explainer.md) and [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) issues!
+
+```js
+quicklink({
+  origins: true,
+  // or
+  origins: []
+});
+```
+
 ## Browser support
 
 The prefetching provided by `quicklink` can be viewed as a [progressive enhancement](https://www.smashingmagazine.com/2009/04/progressive-enhancement-what-it-is-and-how-to-use-it/). Cross-browser support is as follows:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can also grab `quicklink` from [unpkg.com/quicklink](https://unpkg.com/quick
 
 ## Usage
 
-Once initialized, `quicklink` will automatically prefetch URLs for links that are in-viewport during idle time. 
+Once initialized, `quicklink` will automatically prefetch URLs for links that are in-viewport during idle time.
 
 Quickstart:
 
@@ -80,6 +80,8 @@ The above options are best for multi-page sites. Single-page apps have a few opt
 * `timeout`: Integer for the `requestIdleCallback` timeout. A time in milliseconds by which the browser must execute prefetching. Defaults to 2 seconds.
 * `timeoutFn`: Function for specifying a timeout. Defaults to `requestIdleCallback`. Can also be swapped out for a custom function like [networkIdleCallback](https://github.com/pastelsky/network-idle-callback) (see demos)
 * `priority`: Boolean specifying preferred priority for fetches. Defaults to `false`. `true` will attempt to use the `fetch()` API where supported (rather than rel=prefetch)
+* `sameOrigin`: Restricts prefetching to URLs of the same origin. Defaults to `false`. Any truthy value will ensure no cross-domain requests are sent & will override/ignore any `options.origins` value.
+* `origins`: Static array of URL hostname strings that are allowed to be prefetched. Defaults to an empty array, which _allows all_ URLs to be prefetched.
 
 TODO:
 * Explore detecting file-extension of resources and using [rel=preload](https://w3c.github.io/preload/) for high priority fetches
@@ -139,6 +141,34 @@ Defaults to low-priority (`rel=prefetch` or XHR). For high-priority (`priority: 
 quicklink({ priority: true });
 ```
 
+**Allow same-origin requests only**
+
+Forcibly disables all cross-domain requests. All domains are allowed by default.
+
+```js
+quicklink({ sameOrigin: true });
+```
+
+**Specify a custom list of allowed origins**
+
+Provide a list of hostnames that should be prefetch-able. All domains are allowed by default.
+
+> **Important:** You must also include your own hostname!
+
+```js
+quicklink({
+  origins: [
+    // add mine
+    'my-website.com',
+    'api.my-website.com',
+    // add third-parties
+    'other-website.com',
+    'example.com',
+    // ...
+  ]
+});
+```
+
 ## Browser support
 
 The prefetching provided by `quicklink` can be viewed as a [progressive enhancement](https://www.smashingmagazine.com/2009/04/progressive-enhancement-what-it-is-and-how-to-use-it/). Cross-browser support is as follows:
@@ -149,7 +179,7 @@ The prefetching provided by `quicklink` can be viewed as a [progressive enhancem
 Certain features have layered support:
 
 * The [Network Information API](https://wicg.github.io/netinfo/), which is used to check if the user has a slow effective connection type (via `navigator.connection.effectiveType`) is only available in [Chrome 61+ and Opera 57+](https://caniuse.com/#feat=netinfo)
-* If opting for `{priority: true}` and the [Fetch API](https://fetch.spec.whatwg.org/) isn't available, XHR will be used instead. 
+* If opting for `{priority: true}` and the [Fetch API](https://fetch.spec.whatwg.org/) isn't available, XHR will be used instead.
 
 ## Using the prefetcher directly
 
@@ -170,14 +200,14 @@ Promise.all(promises);
 Here's a [WebPageTest run](https://www.webpagetest.org/video/view.php?id=181212_4c294265117680f2636676721cc886613fe2eede&data=1) for our [demo](https://keyword-2-ecd7b.firebaseapp.com/) improving page-load performance by up to 4 seconds via quicklink's prefetching. A [video](https://youtu.be/rQ75YEbJicw) comparison of the before/after prefetching is on YouTube.
 
 For demo purposes, we deployed a version of the [Google Blog](https://blog.google) on
-Firebase hosting. We then deployed another version of it, adding quicklink to the homepage and benchmarked navigating from the homepage to an article that was 
+Firebase hosting. We then deployed another version of it, adding quicklink to the homepage and benchmarked navigating from the homepage to an article that was
 automatically prefetched. The prefetched version loaded faster.
 
 Please note: this is by no means an exhaustive benchmark of the pros and cons of in-viewport link prefetching. Just a demo of the potential improvements the approach can offer. Your own mileage may heavily vary.
 
 ## Related projects
 
-* Using [Gatsby](https://gatsbyjs.org)? You already get most of this for free baked in. It uses `Intersection Observer` to prefetch all of the links that are in view and provided heavy inspiration for this project. 
+* Using [Gatsby](https://gatsbyjs.org)? You already get most of this for free baked in. It uses `Intersection Observer` to prefetch all of the links that are in view and provided heavy inspiration for this project.
 * Want a more data-driven approach? See [Guess.js](https://guess-js.github.io). It uses analytics and machine-learning to prefetch resources based on how users navigate your site. It also has plugins for [Webpack](https://www.npmjs.com/package/guess-webpack) and [Gatsby](https://www.gatsbyjs.org/docs/optimize-prefetching-with-guessjs/).
 
 ## License

--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ The above options are best for multi-page sites. Single-page apps have a few opt
 * `timeout`: Integer for the `requestIdleCallback` timeout. A time in milliseconds by which the browser must execute prefetching. Defaults to 2 seconds.
 * `timeoutFn`: Function for specifying a timeout. Defaults to `requestIdleCallback`. Can also be swapped out for a custom function like [networkIdleCallback](https://github.com/pastelsky/network-idle-callback) (see demos)
 * `priority`: Boolean specifying preferred priority for fetches. Defaults to `false`. `true` will attempt to use the `fetch()` API where supported (rather than rel=prefetch)
-* `sameOrigin`: Restricts prefetching to URLs of the same origin. Defaults to `false`. Any truthy value will ensure no cross-domain requests are sent & will override/ignore any `options.origins` value.
-* `origins`: Static array of URL hostname strings that are allowed to be prefetched. Defaults to an empty array, which _allows all_ URLs to be prefetched.
+* `origins`: Static array of URL hostname strings that are allowed to be prefetched. Defaults to the same domain origin, which prevents _any_ cross-origin requests.
 
 TODO:
 * Explore detecting file-extension of resources and using [rel=preload](https://w3c.github.io/preload/) for high priority fetches
@@ -141,17 +140,9 @@ Defaults to low-priority (`rel=prefetch` or XHR). For high-priority (`priority: 
 quicklink({ priority: true });
 ```
 
-**Allow same-origin requests only**
-
-Forcibly disables all cross-domain requests. All domains are allowed by default.
-
-```js
-quicklink({ sameOrigin: true });
-```
-
 **Specify a custom list of allowed origins**
 
-Provide a list of hostnames that should be prefetch-able. All domains are allowed by default.
+Provide a list of hostnames that should be prefetch-able. Only the same origin is allowed by default.
 
 > **Important:** You must also include your own hostname!
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The above options are best for multi-page sites. Single-page apps have a few opt
 * `timeoutFn`: Function for specifying a timeout. Defaults to `requestIdleCallback`. Can also be swapped out for a custom function like [networkIdleCallback](https://github.com/pastelsky/network-idle-callback) (see demos)
 * `priority`: Boolean specifying preferred priority for fetches. Defaults to `false`. `true` will attempt to use the `fetch()` API where supported (rather than rel=prefetch)
 * `origins`: Static array of URL hostname strings that are allowed to be prefetched. Defaults to the same domain origin, which prevents _any_ cross-origin requests.
+* `ignores`: A RegExp, Function, or Array that further determines if a URL should be prefetched. These execute _after_ origin matching.
 
 TODO:
 * Explore detecting file-extension of resources and using [rel=preload](https://w3c.github.io/preload/) for high priority fetches
@@ -171,6 +172,27 @@ quicklink({
   origins: true,
   // or
   origins: []
+});
+```
+
+**Custom Ignore Patterns**
+
+These filters run _after_ the `origins` matching has run. Ignores can be useful for avoiding large file downloads or for responding to DOM attributes dynamically.
+
+```js
+// Same-origin restraint is enabled by default.
+//
+// This example will ignore all requests to:
+//  - all "/api/*" pathnames
+//  - all ".zip" extensions
+//  - all <a> tags with "noprefetch" attribute
+//
+quicklink({
+  ignores: [
+    /\/api\/?/,
+    uri => uri.includes('.zip'),
+    (uri, elem) => elem.hasAttribute('noprefetch')
+  ]
 });
 ```
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -50,7 +50,7 @@ function prefetcher(url) {
 function isIgnored(node, filter) {
   return Array.isArray(filter)
     ? filter.some(x => isIgnored(node, x))
-    : (filter.test || filter)(node.href, node);
+    : (filter.test || filter).call(filter, node.href, node);
 }
 
 /**

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -48,6 +48,7 @@ function prefetcher(url) {
  * @param {Array} options.urls - Array of URLs to prefetch (override)
  * @param {Object} options.el - DOM element to prefetch in-viewport links of
  * @param {Boolean} options.priority - Attempt higher priority fetch (low or high)
+ * @param {Boolean} options.sameOrigin - Restrict prefetching to assets with same origin.
  * @param {Array} options.origins - Allowed origins to prefetch (empty allows all)
  * @param {Number} options.timeout - Timeout after which prefetching will occur
  * @param {function} options.timeoutFn - Custom timeout function
@@ -62,7 +63,7 @@ export default function (options) {
 
   observer.priority = options.priority;
 
-  const allowed = options.origins || [];
+  const allowed = options.sameOrigin ? [location.hostname] : options.origins || [];
 
   options.timeoutFn(() => {
     // If URLs are given, prefetch them.

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -48,7 +48,6 @@ function prefetcher(url) {
  * @param {Array} options.urls - Array of URLs to prefetch (override)
  * @param {Object} options.el - DOM element to prefetch in-viewport links of
  * @param {Boolean} options.priority - Attempt higher priority fetch (low or high)
- * @param {Boolean} options.sameOrigin - If truthy, restricts prefetching to assets with same origin.
  * @param {Array} options.origins - Allowed origins to prefetch (empty allows all)
  * @param {Number} options.timeout - Timeout after which prefetching will occur
  * @param {Function} options.timeoutFn - Custom timeout function
@@ -63,7 +62,7 @@ export default function (options) {
 
   observer.priority = options.priority;
 
-  const allowed = options.sameOrigin ? [location.hostname] : options.origins || [];
+  const allowed = options.origins || [location.hostname];
 
   options.timeoutFn(() => {
     // If URLs are given, prefetch them.

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -48,10 +48,10 @@ function prefetcher(url) {
  * @param {Array} options.urls - Array of URLs to prefetch (override)
  * @param {Object} options.el - DOM element to prefetch in-viewport links of
  * @param {Boolean} options.priority - Attempt higher priority fetch (low or high)
- * @param {Boolean} options.sameOrigin - Restrict prefetching to assets with same origin.
+ * @param {Boolean} options.sameOrigin - If truthy, restricts prefetching to assets with same origin.
  * @param {Array} options.origins - Allowed origins to prefetch (empty allows all)
  * @param {Number} options.timeout - Timeout after which prefetching will occur
- * @param {function} options.timeoutFn - Custom timeout function
+ * @param {Function} options.timeoutFn - Custom timeout function
  */
 export default function (options) {
   options = Object.assign({

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -48,6 +48,7 @@ function prefetcher(url) {
  * @param {Array} options.urls - Array of URLs to prefetch (override)
  * @param {Object} options.el - DOM element to prefetch in-viewport links of
  * @param {Boolean} options.priority - Attempt higher priority fetch (low or high)
+ * @param {Array} options.origins - Allowed origins to prefetch (empty allows all)
  * @param {Number} options.timeout - Timeout after which prefetching will occur
  * @param {function} options.timeoutFn - Custom timeout function
  */
@@ -61,6 +62,8 @@ export default function (options) {
 
   observer.priority = options.priority;
 
+  const allowed = options.origins || [];
+
   options.timeoutFn(() => {
     // If URLs are given, prefetch them.
     if (options.urls) {
@@ -69,7 +72,11 @@ export default function (options) {
       // If not, find all links and use IntersectionObserver.
       Array.from(options.el.querySelectorAll('a'), link => {
         observer.observe(link);
-        toPrefetch.add(link.href);
+        // If the anchor matches a permitted origin
+        // ~> An empty list means everything is allowed
+        if (!allowed.length || allowed.includes(link.hostname)) {
+          toPrefetch.add(link.href);
+        }
       });
     }
   }, {timeout: options.timeout});

--- a/test/quicklink.spec.js
+++ b/test/quicklink.spec.js
@@ -96,6 +96,22 @@ describe('quicklink tests', function () {
     expect(responseURLs).to.include('https://github.githubassets.com/images/spinners/octocat-spinner-32.gif');
   });
 
+  it('should prefetch all links when allowing all origins', async function () {
+    const responseURLs = [];
+    page.on('response', resp => {
+      responseURLs.push(resp.url());
+    });
+    await page.goto(`${server}/test-allow-origin-all.html`);
+
+    await page.waitFor(1000);
+
+    expect(responseURLs).to.be.an('array');
+    //=> origins: true
+    expect(responseURLs).to.include(`${server}/2.html`);
+    expect(responseURLs).to.include('https://foobar.com/3.html');
+    expect(responseURLs).to.include('https://example.com/1.html');
+    expect(responseURLs).to.include('https://github.githubassets.com/images/spinners/octocat-spinner-32.gif');
+  });
 
   it('should only prefetch links of same origin (default)', async function () {
     const responseURLs = [];

--- a/test/quicklink.spec.js
+++ b/test/quicklink.spec.js
@@ -79,4 +79,35 @@ describe('quicklink tests', function () {
     expect(responseURLs).to.be.an('array');
     expect(responseURLs).to.include(`${server}/main.css`);
   });
+
+  it('should only prefetch links if allowed in origins list', async function () {
+    const responseURLs = [];
+    page.on('response', resp => {
+      responseURLs.push(resp.url());
+    });
+    await page.goto(`${server}/test-allow-origin.html`);
+
+    await page.waitFor(1000);
+
+    expect(responseURLs).to.be.an('array');
+    //=> origins: ['github.githubassets.com']
+    expect(responseURLs).to.not.include(`${server}/2.html`);
+    expect(responseURLs).to.include('https://example.com/1.html');
+    expect(responseURLs).to.include('https://github.githubassets.com/images/spinners/octocat-spinner-32.gif');
+  });
+
+  it('should only prefetch links of same origin', async function () {
+    const responseURLs = [];
+    page.on('response', resp => {
+      responseURLs.push(resp.url());
+    });
+    await page.goto(`${server}/test-same-origin.html`);
+
+    await page.waitFor(1000);
+    expect(responseURLs).to.be.an('array');
+    //=> sameOrigin: true
+    expect(responseURLs).to.include(`${server}/2.html`);
+    expect(responseURLs).to.not.include('https://example.com/1.html');
+    expect(responseURLs).to.not.include('https://github.githubassets.com/images/spinners/octocat-spinner-32.gif');
+  });
 });

--- a/test/quicklink.spec.js
+++ b/test/quicklink.spec.js
@@ -96,7 +96,8 @@ describe('quicklink tests', function () {
     expect(responseURLs).to.include('https://github.githubassets.com/images/spinners/octocat-spinner-32.gif');
   });
 
-  it('should only prefetch links of same origin', async function () {
+
+  it('should only prefetch links of same origin (default)', async function () {
     const responseURLs = [];
     page.on('response', resp => {
       responseURLs.push(resp.url());
@@ -105,7 +106,7 @@ describe('quicklink tests', function () {
 
     await page.waitFor(1000);
     expect(responseURLs).to.be.an('array');
-    //=> sameOrigin: true
+    //=> origins: [location.hostname] (default)
     expect(responseURLs).to.include(`${server}/2.html`);
     expect(responseURLs).to.not.include('https://example.com/1.html');
     expect(responseURLs).to.not.include('https://github.githubassets.com/images/spinners/octocat-spinner-32.gif');

--- a/test/quicklink.spec.js
+++ b/test/quicklink.spec.js
@@ -127,4 +127,37 @@ describe('quicklink tests', function () {
     expect(responseURLs).to.not.include('https://example.com/1.html');
     expect(responseURLs).to.not.include('https://github.githubassets.com/images/spinners/octocat-spinner-32.gif');
   });
+
+  it('should only prefetch links after ignore patterns allowed it', async function () {
+    const responseURLs = [];
+    page.on('response', resp => {
+      responseURLs.push(resp.url());
+    });
+    await page.goto(`${server}/test-ignore-basic.html`);
+
+    await page.waitFor(1000);
+    expect(responseURLs).to.be.an('array');
+    //=> origins: [location.hostname] (default)
+    //=> ignores: /2.html/
+    expect(responseURLs).to.not.include(`${server}/2.html`); // via ignores
+    expect(responseURLs).to.not.include('https://example.com/1.html'); // via same origin
+    expect(responseURLs).to.not.include('https://github.githubassets.com/images/spinners/octocat-spinner-32.gif'); // via same origin
+  });
+
+  it('should only prefetch links after ignore patterns allowed it (multiple)', async function () {
+    const responseURLs = [];
+    page.on('response', resp => {
+      responseURLs.push(resp.url());
+    });
+    await page.goto(`${server}/test-ignore-multiple.html`);
+
+    await page.waitFor(1000);
+    expect(responseURLs).to.be.an('array');
+    //=> origins: true (all)
+    //=> ignores: [...]
+    expect(responseURLs).to.include(`${server}/2.html`);
+    expect(responseURLs).to.not.include('https://example.com/1.html'); // /example/
+    expect(responseURLs).to.not.include('https://foobar.com/3.html'); // (uri) => uri.includes('foobar')
+    expect(responseURLs).to.not.include('https://github.githubassets.com/images/spinners/octocat-spinner-32.gif'); // (uri, elem) => elem.textContent.includes('Spinner')
+  });
 });

--- a/test/test-allow-origin-all.html
+++ b/test/test-allow-origin-all.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Prefetch: Allow All Origins</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" type="text/css" media="screen" href="main.css" />
+    <script src="https://polyfill.io/v2/polyfill.min.js?features=IntersectionObserver"></script>
+</head>
+<body>
+    <a href="https://example.com/1.html">Link 1</a>
+    <a href="2.html">Link 2</a>
+    <a href="https://foobar.com/3.html">Link 3</a>
+    <a href="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">Spinner</a>
+    <section id="stuff">
+        <a href="main.css">CSS</a>
+    </section>
+    <a href="4.html" style="position:absolute;margin-top:900px;">Link 4</a>
+    <script src="../dist/quicklink.umd.js"></script>
+    <script>
+        quicklink({
+            origins: true
+        });
+    </script>
+</body>
+</html>

--- a/test/test-allow-origin.html
+++ b/test/test-allow-origin.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Prefetch: Allowed Origins</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" type="text/css" media="screen" href="main.css" />
+    <script src="https://polyfill.io/v2/polyfill.min.js?features=IntersectionObserver"></script>
+</head>
+<body>
+    <a href="https://example.com/1.html">Link 1</a>
+    <a href="2.html">Link 2</a>
+    <a href="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">Spinner</a>
+    <section id="stuff">
+        <a href="main.css">CSS</a>
+    </section>
+    <a href="4.html" style="position:absolute;margin-top:900px;">Link 4</a>
+    <script src="../dist/quicklink.umd.js"></script>
+    <script>
+        quicklink({
+            origins: ['github.githubassets.com', 'example.com']
+        });
+    </script>
+</body>
+</html>

--- a/test/test-ignore-basic.html
+++ b/test/test-ignore-basic.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Prefetch: Ignore Basic</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" type="text/css" media="screen" href="main.css" />
+    <script src="https://polyfill.io/v2/polyfill.min.js?features=IntersectionObserver"></script>
+</head>
+<body>
+    <a href="https://example.com/1.html">Link 1</a>
+    <a href="2.html">Link 2</a>
+    <a href="https://foobar.com/3.html">Link 3</a>
+    <a href="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">Spinner</a>
+    <section id="stuff">
+        <a href="main.css">CSS</a>
+    </section>
+    <a href="4.html" style="position:absolute;margin-top:900px;">Link 4</a>
+    <script src="../dist/quicklink.umd.js"></script>
+    <script>
+        quicklink({
+            ignores: /2.html/
+        });
+    </script>
+</body>
+</html>

--- a/test/test-ignore-multiple.html
+++ b/test/test-ignore-multiple.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Prefetch: Ignore Multiple</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" type="text/css" media="screen" href="main.css" />
+    <script src="https://polyfill.io/v2/polyfill.min.js?features=IntersectionObserver"></script>
+</head>
+<body>
+    <a href="https://example.com/1.html">Link 1</a>
+    <a href="2.html">Link 2</a>
+    <a href="https://foobar.com/3.html">Link 3</a>
+    <a href="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">Spinner</a>
+    <section id="stuff">
+        <a href="main.css">CSS</a>
+    </section>
+    <a href="4.html" style="position:absolute;margin-top:900px;">Link 4</a>
+    <script src="../dist/quicklink.umd.js"></script>
+    <script>
+        quicklink({
+            origins: true, // allow all initially
+            ignores: [
+                /example/,
+                (uri) => uri.includes('foobar'),
+                (uri, elem) => elem.textContent.includes('Spinner')
+            ]
+        });
+    </script>
+</body>
+</html>

--- a/test/test-same-origin.html
+++ b/test/test-same-origin.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Prefetch: Same Origin</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" type="text/css" media="screen" href="main.css" />
+    <script src="https://polyfill.io/v2/polyfill.min.js?features=IntersectionObserver"></script>
+</head>
+<body>
+    <a href="https://example.com/1.html">Link 1</a>
+    <a href="2.html">Link 2</a>
+    <a href="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">Spinner</a>
+    <section id="stuff">
+        <a href="main.css">CSS</a>
+    </section>
+    <a href="4.html" style="position:absolute;margin-top:900px;">Link 4</a>
+    <script src="../dist/quicklink.umd.js"></script>
+    <script>
+        quicklink({
+            sameOrigin: true
+        });
+    </script>
+</body>
+</html>

--- a/test/test-same-origin.html
+++ b/test/test-same-origin.html
@@ -18,9 +18,7 @@
     <a href="4.html" style="position:absolute;margin-top:900px;">Link 4</a>
     <script src="../dist/quicklink.umd.js"></script>
     <script>
-        quicklink({
-            sameOrigin: true
-        });
+        quicklink();
     </script>
 </body>
 </html>


### PR DESCRIPTION
Pulled my snippet from #31 into a PR.

The `origins` option is a list of permitted hostnames. The `sameOrigin` option indicates whether or not the domain's origin is all that's allowed. 

The use of `origins` and `sameOrigin` are mutually exclusive. If one has additional origins to allow, they should include their own within the larger `origins` array.

Adds 47 bytes in total.

---

_Closes #31, #33, and #38_