### PR TITLE
Fix: Use "unpkg" entry path

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "module": "dist/quicklink.mjs",
   "jsnext:main": "dist/quicklink.mjs",
   "umd:main": "dist/quicklink.umd.js",
+  "unpkg": "dist/quicklink.umd.js",
   "scripts": {
     "lint": "eslint src/*.mjs test/*.js demos/*.js",
     "lint-fix": "eslint src/*.mjs test/*.js --fix demos/*.js",


### PR DESCRIPTION
The `unpkg.com` service looks for an `"unpkg"` key initially, falling back to the `"main"` entry.

Since our `"main"` is CommonJS, this will break any & all `unpkg.com` links unless one has knowledge of the `dist/*` contents.

This adds that `unpkg` path, allowing the README example link to work.

---

_Closes #39_