### PR TITLE
unpkg link to umd version to avoid issue #39

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For use with [node](http://nodejs.org) and [npm](https://npmjs.com):
 npm install --save quicklink
 ```
 
-You can also grab `quicklink` from [unpkg.com/quicklink](https://unpkg.com/quicklink).
+You can also grab `quicklink` from [unpkg.com/quicklink](https://unpkg.com/quicklink/dist/quicklink.umd.js).
 
 ## Usage
 


### PR DESCRIPTION
The unpkg.com link from the documentation is not working because the unpkg link redirects to ```/dist/quicklink.js``` instead of ```/dist/quicklink.umd.js``` as mentioned by #39