### PR TITLE
fix(README): use UMD file for <script> tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Quickstart:
 
 ```html
 <!-- Include quicklink from dist -->
-<script src="dist/quicklink.js"></script>
+<script src="dist/quicklink.umd.js"></script>
 <!-- Initialize (you can do this whenever you want) -->
 <script>
 quicklink();


### PR DESCRIPTION
Browsers should use the UMD file (unless importing as ES modules).

ref: https://github.com/GoogleChromeLabs/quicklink/issues/39

cc: @lukeed 