### PR TITLE
Update microbundle to fix "missing JSX plugin" issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-config-google": "^0.11.0",
     "http-server": "^0.11.1",
     "lodash": "^4.17.11",
-    "microbundle": "^0.7.0",
+    "microbundle": "^0.9.0",
     "mocha": "^5.2.0",
     "puppeteer": "^1.10.0"
   },


### PR DESCRIPTION
There are no breaking changes from 0.7 -> 0.9. Size remains the same.