### PR TITLE
Size optimizations

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -72,25 +72,23 @@ function isIgnored(node, filter) {
  * @param {Function} options.timeoutFn - Custom timeout function
  */
 export default function (options) {
-  options = Object.assign({
-    timeout: 2e3,
-    priority: false,
-    timeoutFn: requestIdleCallback,
-    el: document,
-  }, options);
+  if (!options) options = {};
 
-  observer.priority = options.priority;
+  observer.priority = options.priority || false;
 
   const allowed = options.origins || [location.hostname];
   const ignores = options.ignores || [];
 
-  options.timeoutFn(() => {
+  const timeout = options.timeout || 2e3;
+  const timeoutFn = options.timeoutFn || requestIdleCallback;
+
+  timeoutFn(() => {
     // If URLs are given, prefetch them.
     if (options.urls) {
       options.urls.forEach(prefetcher);
     } else {
       // If not, find all links and use IntersectionObserver.
-      Array.from(options.el.querySelectorAll('a'), link => {
+      Array.from((options.el || document).querySelectorAll('a'), link => {
         observer.observe(link);
         // If the anchor matches a permitted origin
         // ~> A `[]` or `true` means everything is allowed
@@ -100,5 +98,5 @@ export default function (options) {
         }
       });
     }
-  }, {timeout: options.timeout});
+  }, {timeout});
 }

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -26,7 +26,7 @@ const preFetched = {};
  */
 function support(feature) {
   const link = document.createElement('link');
-  return (link.relList || {}).supports && link.relList.supports(feature);
+  return link.relList && link.relList.supports && link.relList.supports(feature);
 }
 
 /**


### PR DESCRIPTION
This PR introduces a few quick size optimizations, mainly inlining the `options` handling to avoid the call to `Object.assign()` (instead applying defaults throughout the exported function).

One thought I had was that hoisting these defaults into constants would be free (they get inlined by microbundle/terser) and bring back some of the visibility lost from removing the assign().

/cc @lukeed 