### PR TITLE
Add note to README about Drupal module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Please note: this is by no means an exhaustive benchmark of the pros and cons of
 * Using [Gatsby](https://gatsbyjs.org)? You already get most of this for free baked in. It uses `Intersection Observer` to prefetch all of the links that are in view and provided heavy inspiration for this project.
 * Want a more data-driven approach? See [Guess.js](https://guess-js.github.io). It uses analytics and machine-learning to prefetch resources based on how users navigate your site. It also has plugins for [Webpack](https://www.npmjs.com/package/guess-webpack) and [Gatsby](https://www.gatsbyjs.org/docs/optimize-prefetching-with-guessjs/).
 * WordPress users can now get quicklink as a [WordPress Plugin from the plugin repository](https://wordpress.org/plugins/quicklink/).
+* Drupal users can install the [Quicklink Drupal module](https://www.drupal.org/project/quicklink).
 * Want less aggressive prefetching? [instant.page](https://instant.page/) prefetches on mouseover and touchstart, right before a click.
 
 ## License


### PR DESCRIPTION
This commit adds a small note mentioning the [Quicklink module for Drupal](https://www.drupal.org/project/quicklink).