### PR TITLE
GitHub Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Something is not working as expected
+labels: 
+---
+
+**Before you start**
+Please take a look at the [FAQ](https://github.com/GoogleChromeLabs/quicklink/wiki/FAQ) as well as the already opened issues! If nothing fits your problem, go ahead and fill out the following template:
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Version:**
+ - OS w/ version: [e.g. iOS 12]
+ - Browser w/ version [e.g. Chrome 75]
+
+**Additional context, screenshots, screencasts**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: 
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
These issue templates may help to reduce support requests and cut down on back and forth getting details of reported issues.

Fixes: #107