### PR TITLE
Check if `requestIdleCallback` exists in `window`

### DIFF
--- a/src/request-idle-callback.mjs
+++ b/src/request-idle-callback.mjs
@@ -15,7 +15,7 @@
 **/
 
 // RIC and shim for browsers setTimeout() without it
-const requestIdleCallback = requestIdleCallback ||
+const requestIdleCallback = window.requestIdleCallback ||
   function (cb) {
     const start = Date.now();
     return setTimeout(function () {


### PR DESCRIPTION
Fixes the following error when not transpiled:
> Uncaught ReferenceError: Cannot access 'requestIdleCallback' before initialization
>   at request-idle-callback.mjs:18

It doesn’t throw when being transpiled to ES5 because it uses `var` instead of `const`.