### PR TITLE
Chore: More Golfing~

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -74,7 +74,7 @@ function isIgnored(node, filter) {
 export default function (options) {
   if (!options) options = {};
 
-  observer && (observer.priority = options.priority || false);
+  if (observer) observer.priority = !!options.priority;
 
   const allowed = options.origins || [location.hostname];
   const ignores = options.ignores || [];
@@ -88,7 +88,7 @@ export default function (options) {
       options.urls.forEach(prefetcher);
     } else if (observer) {
       // If not, find all links and use IntersectionObserver.
-      Array.from((options.el || document).querySelectorAll('a'), link => {
+      (options.el || document).querySelectorAll('a').forEach(link => {
         observer.observe(link);
         // If the anchor matches a permitted origin
         // ~> A `[]` or `true` means everything is allowed

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -53,7 +53,7 @@ function prefetcher(url) {
 function isIgnored(node, filter) {
   return Array.isArray(filter)
     ? filter.some(x => isIgnored(node, x))
-    : (filter.test || filter).call(filter, node.href, node);
+    : filter && (filter.test || filter).call(filter, node.href, node);
 }
 
 /**
@@ -77,9 +77,6 @@ export default function (options) {
   if (observer) observer.priority = !!options.priority;
 
   const allowed = options.origins || [location.hostname];
-  const ignores = options.ignores || [];
-
-  const timeout = options.timeout || 2e3;
   const timeoutFn = options.timeoutFn || requestIdleCallback;
 
   timeoutFn(() => {
@@ -94,9 +91,11 @@ export default function (options) {
         // ~> A `[]` or `true` means everything is allowed
         if (!allowed.length || allowed.includes(link.hostname)) {
           // If there are any filters, the link must not match any of them
-          isIgnored(link, ignores) || toPrefetch.add(link.href);
+          isIgnored(link, options.ignores) || toPrefetch.add(link.href);
         }
       });
     }
-  }, {timeout});
+  }, {
+    timeout: options.timeout || 2e3
+  });
 }


### PR DESCRIPTION
While not much, it can't hurt 😇 I do have another (unpushed) commit that brings this down further; see below.

***Before:***

```
        804 B: quicklink.js.gz
        667 B: quicklink.js.br
        804 B: quicklink.mjs.gz
        668 B: quicklink.mjs.br
        877 B: quicklink.umd.js.gz
        729 B: quicklink.umd.js.br
```

***After:***

```
        795 B: quicklink.js.gz
        661 B: quicklink.js.br
        795 B: quicklink.mjs.gz
        663 B: quicklink.mjs.br
        870 B: quicklink.umd.js.gz
        725 B: quicklink.umd.js.br
```

***Possible:***

```
        788 B: quicklink.js.gz
        654 B: quicklink.js.br
        789 B: quicklink.mjs.gz
        657 B: quicklink.mjs.br
        864 B: quicklink.umd.js.gz
        721 B: quicklink.umd.js.br
```

The  gotcha here though is that it removes the `window.` prefixes on `IntersectionObserver` and `requestIdleCallback`. This means that browsers that don't support them will throw an Error instead of silently doing nothing. 

That's a big change, so didn't push it