### PR TITLE
feat(options): Add a `hrefFn` option to build the URL to prefetch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ Default: None
 An optional error handler that will receive any errors from prefetched requests.<br>
 By default, these errors are silently ignored.
 
+#### options.hrefFn
+Type: `Function`<br>
+Default: None
+
+An optional function to generate the URL to prefetch. It receives an [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) as the argument.
 
 ### quicklink.prefetch(urls, isPriority)
 Returns: `Promise`

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -20,6 +20,7 @@
 /**
  * Checks if a feature on `link` is natively supported.
  * Examples of features include `prefetch` and `preload`.
+ * @param {Object} link Link object.
  * @return {Boolean} whether the feature is supported
  */
 function hasPrefetch(link) {

--- a/test/quicklink.spec.js
+++ b/test/quicklink.spec.js
@@ -96,7 +96,7 @@ describe('quicklink tests', function () {
     expect(responseURLs).to.be.an('array');
     // => origins: true
     expect(responseURLs).to.include(`${server}/2.html`);
-    expect(responseURLs).to.include('https://foobar.com/3.html');
+    expect(responseURLs).to.include('https://google.com/');
     expect(responseURLs).to.include('https://example.com/1.html');
     expect(responseURLs).to.include('https://github.githubassets.com/images/spinners/octocat-spinner-32.gif');
   });
@@ -238,7 +238,7 @@ describe('quicklink tests', function () {
       if (/test\/\d+\.html$/i.test(req.url())) {
         await sleep(100);
         URLs.push(req.url());
-        return req.respond({ status: 200 });
+        return req.respond({status: 200});
       }
       req.continue();
     });
@@ -254,5 +254,21 @@ describe('quicklink tests', function () {
     // Note: Parallel requests, w/ 50ms buffer
     await page.waitFor(250);
     expect(URLs.length).to.equal(4);
+  });
+
+  it('should prefetch using a custom function to build the URL', async function () {
+    const responseURLs = [];
+    page.on('response', resp => {
+      responseURLs.push(resp.url());
+    });
+    await page.goto(`${server}/test-custom-href-function.html`);
+    await page.waitFor(1000);
+
+    // don't care about first 4 URLs (markup)
+    const ours = responseURLs.slice(4);
+    expect(ours).to.include(`https://example.com/?url=${server}/1.html`);
+    expect(ours).to.include(`https://example.com/?url=${server}/2.html`);
+    expect(ours).to.include(`https://example.com/?url=${server}/3.html`);
+    expect(ours).to.include(`https://example.com/?url=${server}/4.html`);
   });
 });

--- a/test/test-allow-origin-all.html
+++ b/test/test-allow-origin-all.html
@@ -13,7 +13,7 @@
 <body>
     <a href="https://example.com/1.html">Link 1</a>
     <a href="2.html">Link 2</a>
-    <a href="https://foobar.com/3.html">Link 3</a>
+    <a href="https://google.com/">Link 3</a>
     <a href="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">Spinner</a>
     <section id="stuff">
         <a href="main.css">CSS</a>

--- a/test/test-custom-href-function.html
+++ b/test/test-custom-href-function.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Prefetch: Custom function to build the URL.</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" media="screen" href="main.css">
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
+</head>
+
+<body>
+  <a href="1.html">Link 1</a>
+  <a href="2.html">Link 2</a>
+  <a href="3.html">Link 3</a>
+  <a href="4.html">Link 4</a>
+  <script src="../dist/quicklink.umd.js"></script>
+  <script>
+    quicklink.listen({
+        hrefFn: (entry) => ( `https://example.com/?url=${entry.href}` ),
+    });
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
### Description
- adds `hrefFn` option - If this function is supplied, then it will be used to generate the URL to prefetch instead of using the `entry.href`.

### Why ?
I'm building a SPA which renders the links with `href` to a HTML page, however, there is an `onClick` listener for every link:
1. It fetches a Rest API sending the link `href`. The API returns a JSON.
2. The JSON is used to update the state of the SPA so it will update the UI to render the new page.

I need to prefetch the URL for the Rest API rather than the URL for the actual page.
```
<a href="https://www.webapage.com/article-1">Article 1</a>
```
 I want to prefetch https://rest-api.com/?url=https://www.webapage.com/article-1

