### PR TITLE
[core] Observe more than 1 DOM element

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ Returns: `Function`
 A "reset" function is returned, which will empty the active `IntersectionObserver` and the cache of URLs that have already been prefetched. This can be used between page navigations and/or when significant DOM changes have occurred.
 
 #### options.el
-Type: `HTMLElement`<br>
-Default: `document.body`
+Type: `HTMLElement|Array<HTMLElement>`<br>
+Default: `document`
 
-The DOM element to observe for in-viewport links to prefetch.
+The DOM element(s) to observe for in-viewport links to prefetch.
 
 #### options.limit
 Type: `Number`<br>

--- a/test/quicklink.spec.js
+++ b/test/quicklink.spec.js
@@ -69,6 +69,18 @@ describe('quicklink tests', function () {
     expect(responseURLs).to.include(`${server}/main.css`);
   });
 
+  it('should prefetch in-viewport links from multiple custom DOM sources', async function () {
+    const responseURLs = [];
+    page.on('response', resp => {
+      responseURLs.push(resp.url());
+    });
+    await page.goto(`${server}/test-custom-dom-source-multiple.html`);
+    await page.waitFor(1000);
+    expect(responseURLs).to.be.an('array');
+    expect(responseURLs).to.include(`${server}/2.html`);
+    expect(responseURLs).to.include(`${server}/3.html`);
+  });
+
   it('should only prefetch links if allowed in origins list', async function () {
     const responseURLs = [];
     page.on('response', resp => {

--- a/test/test-custom-dom-source-multiple.html
+++ b/test/test-custom-dom-source-multiple.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>Prefetch: Multiple Custom DOM source</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" media="screen" href="main.css" />
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
+  </head>
+
+  <body>
+    <a href="1.html">Link 1</a>
+    <section id="stuff1">
+      <a href="2.html">Link 2</a>
+    </section>
+    <section id="stuff2">
+      <a href="3.html">Link 3</a>
+    </section>
+    <a href="4.html" style="position: absolute; margin-top: 900px;">Link 4</a>
+    <script src="../dist/quicklink.umd.js"></script>
+    <script>
+      quicklink.listen({
+        el: [
+          document.getElementById("stuff1"),
+          document.getElementById("stuff2"),
+        ],
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
You are doing something great guys and I want to contribute.
I am newbie contributing so I appreciate you understand. If there is some mistake or improvements to do I will be more than happy to receive your feedback.

This PR is related to the FR in the issue #182 . I modified the `index.mjs` to accept an HTMLelement or an array of HTMLelements and iterate through them as necessary to observe the links. 
I also tried to write the test and update the `README`.