### PR TITLE
Fix: Cannot read property 'then' of undefined

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": false,
+    "source.organizeImports": false
+  },
+  "editor.formatOnSave": true
+}

--- a/src/chunks.mjs
+++ b/src/chunks.mjs
@@ -121,7 +121,12 @@ export function listen(options) {
 export function prefetch(url, isPriority, conn) {
   if (conn = navigator.connection) {
     // Don't prefetch if using 2G or if Save-Data is enabled.
-    if (conn.saveData || /2g/.test(conn.effectiveType)) return;
+    if (conn.saveData) {
+      return Promise.reject(new Error('Cannot prefetch, Save-Data is enabled'));
+    }
+    if (/2g/.test(conn.effectiveType)) {
+      return Promise.reject(new Error('Cannot prefetch, network conditions are poor'));
+    }
   }
 
   // Dev must supply own catch()

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -114,7 +114,12 @@ export function listen(options) {
 export function prefetch(url, isPriority, conn) {
   if (conn = navigator.connection) {
     // Don't prefetch if using 2G or if Save-Data is enabled.
-    if (conn.saveData || /2g/.test(conn.effectiveType)) return;
+    if (conn.saveData) {
+      return Promise.reject(new Error('Cannot prefetch, Save-Data is enabled'));
+    }
+    if (/2g/.test(conn.effectiveType)) {
+      return Promise.reject(new Error('Cannot prefetch, network conditions are poor'));
+    }
   }
 
   // Dev must supply own catch()
@@ -126,7 +131,7 @@ export function prefetch(url, isPriority, conn) {
         toPrefetch.add(str);
 
         return (isPriority ? priority : supported)(
-          new URL(str, location.href).toString()
+            new URL(str, location.href).toString()
         );
       }
     })


### PR DESCRIPTION
This PR fixes a `Cannot read property 'then' of undefined` error that gets thrown when this condition is met:
```
if (conn = navigator.connection) {
  // Don't prefetch if using 2G or if Save-Data is enabled.
  if (conn.saveData || /2g/.test(conn.effectiveType)) return;
}
```
`prefetch` is meant to return a Promise, however in this instance it returns `undefined`, meaning that this throws:
```
prefetch(entry.href, options.priority).then(isDone).catch(err => {
  isDone(); if (options.onError) options.onError(err);
});
```
I tried to add tests for this, but I could not figure out a way of mocking either `saveData` or a 2g connection - I tried multiple approaches, with none working. If anyone has any ideas then I'm happy to add the tests to cover this.