### PR TITLE
Added `delay` option to reduce impact on CDNs and servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ Returns: `Function`
 
 A "reset" function is returned, which will empty the active `IntersectionObserver` and the cache of URLs that have already been prefetched. This can be used between page navigations and/or when significant DOM changes have occurred.
 
+#### options.delay
+Type: `Number`<br>
+Default: `0`
+
+The _amount of time_ each link needs to stay inside the viewport before being prefetched, in milliseconds.
+
 #### options.el
 Type: `HTMLElement`<br>
 Default: `document.body`

--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ Default: `Infinity`
 
 The _total_ requests that can be prefetched while observing the `options.el` container.
 
+#### options.threshold
+Type: `Number`<br>
+Default: `0`
+
+The _area percentage_ of each link that must have entered the viewport to be fetched, in its decimal form (e.g. 0.25 = 25%).
+
 #### options.throttle
 Type: `Number`<br>
 Default: `Infinity`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quicklink",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Faster subsequent page-loads by prefetching in-viewport links during idle time",
   "repository": "https://github.com/GoogleChromeLabs/quicklink.git",
   "homepage": "https://getquick.link/",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint src/*.mjs test/*.js demos/*.js",
     "lint-fix": "eslint src/*.mjs test/*.js --fix demos/*.js",
     "start": "http-server .",
-    "test": "yarn run build-all && mocha test/bootstrap.js --recursive test",
+    "test": "yarn run build-all && mocha test/bootstrap.js --timeout 3000 --recursive test",
     "build": "microbundle src/index.mjs --no-sourcemap --external none",
     "build-plugin": "microbundle src/chunks.mjs --no-sourcemap --external none -o dist/react",
     "build-all": "yarn run build && yarn run build-plugin && yarn run build-react-chunks",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quicklink",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Faster subsequent page-loads by prefetching in-viewport links during idle time",
   "repository": "https://github.com/GoogleChromeLabs/quicklink.git",
   "homepage": "https://getquick.link/",

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -49,6 +49,7 @@ function isIgnored(node, filter) {
  * @param {Array|RegExp|Function} [options.ignores] - Custom filter(s) that run after origin checks
  * @param {Number} [options.timeout] - Timeout after which prefetching will occur
  * @param {Number} [options.throttle] - The concurrency limit for prefetching
+ * @param {Number} [options.threshold] - The area percentage of each link that must have entered the viewport to be fetched
  * @param {Number} [options.limit] - The total number of prefetches to allow
  * @param {Number} [options.delay] - Time each link needs to stay inside viewport before prefetching (milliseconds)
  * @param {Function} [options.timeoutFn] - Custom timeout function
@@ -64,6 +65,7 @@ export function listen(options) {
   const [toAdd, isDone] = throttle(options.throttle || 1 / 0);
   const limit = options.limit || 1 / 0;
   const delay = options.delay || 0;
+  const threshold = options.threshold || 0;
 
   const allowed = options.origins || [location.hostname];
   const ignores = options.ignores || [];
@@ -117,7 +119,7 @@ export function listen(options) {
     });
   };
 
-  const observer = new IntersectionObserver(intersectionCallback);
+  const observer = new IntersectionObserver(intersectionCallback, { threshold });
 
   timeoutFn(() => {
     // Find all links & Connect them to IO if allowed

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -111,8 +111,7 @@ export function listen(options) {
   const intersectionCallback = entries => {
     entries.forEach(entry => {
       const link = entry.target;
-      const onFn = entry.isIntersecting ? onEnter : onExit;
-      onFn(link);
+      entry.isIntersecting ? onEnter(link) : onExit(link);
     });
   };
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -105,6 +105,7 @@ export function listen(options) {
 
   const onExit = link => {
     const index = hrefsInViewport.indexOf(link.href);
+    if (index === -1) return;
     hrefsInViewport.splice(index);
   };
 

--- a/test/quicklink.spec.js
+++ b/test/quicklink.spec.js
@@ -302,4 +302,27 @@ describe('quicklink tests', function () {
     await page.waitFor(200);
     expect(responseURLs).to.include(`${server}/4.html`);
   });
+
+  it('should consider threshold option before prefetching (UMD)', async function () {
+    const responseURLs = [];
+    page.on('response', resp => {
+      responseURLs.push(resp.url());
+    });
+
+    await page.goto(`${server}/test-threshold.html`);
+    await page.setViewport({
+      width: 1000,
+      height: 800,
+    });
+    await page.waitFor(1000);
+    expect(responseURLs).to.be.an('array');
+    expect(responseURLs).to.include(`${server}/1.html`);
+    expect(responseURLs).to.include(`${server}/2.html`);
+    await page.evaluate(_ => {
+      window.scrollBy(0, window.innerHeight);
+    });
+    await page.waitFor(400);
+    expect(responseURLs).to.include(`${server}/3.html`);
+    expect(responseURLs).to.include(`${server}/4.html`);
+  });
 });

--- a/test/quicklink.spec.js
+++ b/test/quicklink.spec.js
@@ -274,4 +274,32 @@ describe('quicklink tests', function () {
     expect(ours).to.include(`https://example.com/?url=${server}/3.html`);
     expect(ours).to.include(`https://example.com/?url=${server}/4.html`);
   });
+
+  it('should delay prefetch for in-viewport links correctly (UMD)', async function () {
+    const responseURLs = [];
+    page.on('response', resp => {
+      responseURLs.push(resp.url());
+    });
+    await page.goto(`${server}/test-delay.html`);
+    await page.waitFor(1000);
+    expect(responseURLs).to.be.an('array');
+    expect(responseURLs).to.include(`${server}/1.html`);
+    expect(responseURLs).to.include(`${server}/2.html`);
+    expect(responseURLs).to.include(`${server}/3.html`);
+    // Scroll down and up
+    await page.evaluate(_ => {
+      window.scrollBy(0, window.innerHeight);
+    });
+    await page.waitFor(100);
+    await page.evaluate(_ => {
+      window.scrollBy(0, -window.innerHeight);
+    });
+    expect(responseURLs).not.to.include(`${server}/4.html`);
+    // Scroll down and test
+    await page.evaluate(_ => {
+      window.scrollBy(0, window.innerHeight);
+    });
+    await page.waitFor(200);
+    expect(responseURLs).to.include(`${server}/4.html`);
+  });
 });

--- a/test/test-delay.html
+++ b/test/test-delay.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>Prefetch: Basic Usage</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" media="screen" href="main.css" />
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
+  </head>
+
+  <body>
+    <a href="1.html">Link 1</a>
+    <a href="2.html">Link 2</a>
+    <a href="3.html">Link 3</a>
+    <section id="stuff">
+      <a href="main.css">CSS</a>
+    </section>
+    <a href="4.html" style="position: absolute; margin-top: 900px">Link 4</a>
+    <script src="../dist/quicklink.umd.js"></script>
+    <script>
+      quicklink.listen({ delay: 200 });
+    </script>
+  </body>
+</html>

--- a/test/test-threshold.html
+++ b/test/test-threshold.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Prefetch: Basic Usage</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" media="screen" href="main.css">
+  <style>
+    ul {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-evenly;
+    }
+
+    li {
+      margin-bottom: 32px;
+    }
+
+    a {
+      display: block;
+      width: 400px;
+      height: 600px;
+      background: #ccc;
+      text-align: center;
+    }
+  </style>
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
+</head>
+
+<body>
+  <ul>
+    <li>
+      <a href="1.html">Link 1</a>
+    </li>
+    <li>
+      <a href="2.html">Link 2</a>
+    </li>
+    <li>
+      <a href="3.html">Link 3</a>
+    </li>
+    <li>
+      <a href="4.html">Link 4</a>
+    </li>
+  </ul>
+  <script src="../dist/quicklink.umd.js"></script>
+  <script>
+    quicklink.listen({threshold: 0.5});
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
Added the `delay` option, which is useful to prevent QuickLink from prefetching too much links and have a heavy impact on CDN and servers.

> Type: `Number`
> Default: `0`
> 
> The _amount of time_ each link needs to stay inside the viewport before being prefetched, in milliseconds.

Unlike `throttle` option which prefetches the links in order of appearance, this option makes sure the links _currently inside the viewport_ are prefetched.

So for example, having 40 links in the page and users scrolling down fast to the 40th...

- with `throttle: 4`, QuickLink prefetches the first 4 links, then the 5th, 6th, 7th ... and finally the 40th
- with `delay: 500`, QuickLink prefetches only the first ones that are in viewport, then if users scroll fast enough, the 39th, the 40th, etc. because the previous 38 links didn't stay in-viewport for 500 ms

Note that the `throttle` and `delay` options can still be used together.

I hope you like and merge this PR.