### PR TITLE
Specify code language for the React HOC example

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Wrap your routes with the `withQuicklink()` HOC.
 
 Example:
 
-```sh
+```jsx
 import { withQuicklink } from 'quicklink/dist/react/hoc.js';
 
 const options = {


### PR DESCRIPTION
This enables correct syntax highlighting for the example code block.