### PR TITLE
chore: Modify repository default languages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.njk linguist-language=js


### PR DESCRIPTION
In the search results are displayed **Nunjucks**, which is not conducive to users to find
![image](https://user-images.githubusercontent.com/48512251/176343029-9eab2935-6d23-44d9-b000-253c93187f03.png)

Warehouse language before and after comparison: 
![image](https://user-images.githubusercontent.com/48512251/176343133-d209073c-5ed6-4fbc-9b80-b0522c645a08.png)
![image](https://user-images.githubusercontent.com/48512251/176343269-fc5547eb-7ca4-4154-85e6-f92aa9dc0373.png)
