### PR TITLE
Added support to observe a specific Anchor NodeList collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,7 @@ Quickstart:
 <script src="dist/quicklink.umd.js"></script>
 <!-- Initialize (you can do this whenever you want) -->
 <script>
-  quicklink.listen({
-    el: document.querySelectorAll('a.linksToPrefetch'),
-  });
+  quicklink.listen();
 </script>
 ```
 
@@ -57,9 +55,7 @@ For example, you can initialize after the `load` event fires:
 ```html
 <script>
 window.addEventListener('load', () =>{
-  quicklink.listen({
-    el: document.querySelectorAll('a.linksToPrefetch'),
-  });
+  quicklink.listen();
 });
 </script>
 ```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ Quickstart:
 <script src="dist/quicklink.umd.js"></script>
 <!-- Initialize (you can do this whenever you want) -->
 <script>
-quicklink.listen();
+  quicklink.listen({
+    el: document.querySelectorAll('a.linksToPrefetch'),
+  });
 </script>
 ```
 
@@ -55,7 +57,9 @@ For example, you can initialize after the `load` event fires:
 ```html
 <script>
 window.addEventListener('load', () =>{
-  quicklink.listen();
+  quicklink.listen({
+    el: document.querySelectorAll('a.linksToPrefetch'),
+  });
 });
 </script>
 ```
@@ -129,10 +133,9 @@ Default: `0`
 The _amount of time_ each link needs to stay inside the viewport before being prefetched, in milliseconds.
 
 #### options.el
-Type: `HTMLElement`<br>
+Type: `HTMLElement|NodeList<A>`<br>
 Default: `document.body`
-
-The DOM element to observe for in-viewport links to prefetch.
+The DOM element to observe for in-viewport links to prefetch or the NodeList of Anchor Elements.
 
 #### options.limit
 Type: `Number`<br>
@@ -270,6 +273,16 @@ Defaults to 2 seconds (via `requestIdleCallback`). Here we override it to 4 seco
 ```js
 quicklink.listen({
   timeout: 4000
+});
+```
+
+### Set a specific Anchor Elements NodeList to observe for in-viewport links
+
+Defaults to `document` otherwise.
+
+```js
+quicklink.listen({
+  el: document.querySelectorAll('a.linksToPrefetch')
 });
 ```
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -68,7 +68,7 @@ function checkConnection (conn) {
  * links for `document`. Can also work off a supplied
  * DOM element or static array of URLs.
  * @param {Object} options - Configuration options for quicklink
- * @param {Object} [options.el] - DOM element to prefetch in-viewport links of
+ * @param {Object|Array} [options.el] - DOM element(s) to prefetch in-viewport links of
  * @param {Boolean} [options.priority] - Attempt higher priority fetch (low or high)
  * @param {Array} [options.origins] - Allowed origins to prefetch (empty allows all)
  * @param {Array|RegExp|Function} [options.ignores] - Custom filter(s) that run after origin checks
@@ -171,7 +171,12 @@ export function listen(options) {
 
   timeoutFn(() => {
     // Find all links & Connect them to IO if allowed
-    (options.el || document).querySelectorAll('a').forEach(link => {
+    let elementsToListen;
+    if (options.el && options.el.length && options.el.length > 0 && options.el[0].nodeName == 'A')
+        elementsToListen = options.el;
+    else 
+      elementsToListen = (options.el || document).querySelectorAll('a');
+    elementsToListen.forEach(link => {
       // If the anchor matches a permitted origin
       // ~> A `[]` or `true` means everything is allowed
       if (!allowed.length || allowed.includes(link.hostname)) {

--- a/test/quicklink.spec.js
+++ b/test/quicklink.spec.js
@@ -69,6 +69,18 @@ describe('quicklink tests', function () {
     expect(responseURLs).to.include(`${server}/main.css`);
   });
 
+  it('should prefetch in-viewport links from NodeList', async function () {
+    const responseURLs = [];
+    page.on('response', resp => {
+      responseURLs.push(resp.url());
+    });
+    await page.goto(`${server}/test-node-list.html`);
+    await page.waitFor(1000);
+    expect(responseURLs).to.be.an('array');
+    expect(responseURLs).to.include(`${server}/2.html`);
+    expect(responseURLs).to.include(`${server}/3.html`);
+  });
+
   it('should only prefetch links if allowed in origins list', async function () {
     const responseURLs = [];
     page.on('response', resp => {

--- a/test/test-node-list.html
+++ b/test/test-node-list.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>Prefetch: NodeList case</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" media="screen" href="main.css" />
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
+  </head>
+
+  <body>
+    <a href="1.html">Link 1</a>
+    <section id="stuff1">
+      <a href="2.html" class="linksToPrefetch">Link 2</a>
+    </section>
+    <section id="stuff2">
+      <a href="3.html" class="linksToPrefetch">Link 3</a>
+    </section>
+    <a href="4.html" style="position: absolute; margin-top: 900px;">Link 4</a>
+    <script src="../dist/quicklink.umd.js"></script>
+    <script>
+      quicklink.listen({
+        el: document.querySelectorAll('a.linksToPrefetch'),
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Took some inspiration from PR [183](https://github.com/GoogleChromeLabs/quicklink/pull/183) from @cajotafer.

Proposal: Allow to observe links specified via a specific NodeList collection of Anchor Elements.
