### PR TITLE
feat: added minConnectionType to the options attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,13 @@ Default: None
 
 An optional function to generate the URL to prefetch. It receives an [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) as the argument.
 
+#### options.minConnectionType
+
+Type: ` 'slow-2g' | '2g' | '3g' | '4g' | 'none'` <br>
+Default: '3g'
+
+An optional string that limits the minimum connection to prefetch
+
 ### quicklink.prefetch(urls, isPriority)
 Returns: `Promise`
 


### PR DESCRIPTION
a new options that gives developer the power of choosing which type of connection should be the minimum to prefetch or prerender the link, instead of always it being 3g.