### PR TITLE
Lint tweaks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,14 @@ module.exports = {
       }
     ],
     'no-negated-condition': 'warn',
+    'prefer-destructuring': [
+      'off',
+      {
+        object: true,
+        array: false
+      }
+    ],
+    'prefer-template': 'error',
     'spaced-comment': [
       'error',
       'always',

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -53,6 +53,7 @@ function checkConnection(conn) {
     if (conn.saveData) {
       return new Error('Save-Data is enabled');
     }
+
     if (/2g/.test(conn.effectiveType)) {
       return new Error('network conditions are poor');
     }
@@ -85,12 +86,11 @@ function checkConnection(conn) {
  * @param {Boolean} [options.prerenderAndPrefetch] - Option to use both prerendering and prefetching
  * @return {Function}
  */
-export function listen(options) {
-  if (!options) options = {};
+export function listen(options = {}) {
   if (!window.IntersectionObserver) return;
 
-  const [toAdd, isDone] = throttle(options.throttle || 1/0);
-  const limit = options.limit || 1/0;
+  const [toAdd, isDone] = throttle(options.throttle || 1 / 0);
+  const limit = options.limit || 1 / 0;
   const threshold = options.threshold || 0;
 
   const allowed = options.origins || [location.hostname];
@@ -111,6 +111,7 @@ export function listen(options) {
       callback();
       return;
     }
+
     setTimeout(callback, delay);
   };
 
@@ -125,31 +126,31 @@ export function listen(options) {
         // Setting timeout
         setTimeoutIfDelay(() => {
           // Do not prefetch if not found in viewport
-          if (hrefsInViewport.indexOf(entry.href) === -1) return;
+          if (!hrefsInViewport.includes(entry.href)) return;
 
           observer.unobserve(entry);
 
           // prerender, if..
           // either it's the prerender + prefetch mode or it's prerender *only* mode
           // && no link has been prerendered before (no spec rules defined)
-          if (shouldPrerenderAndPrefetch || shouldOnlyPrerender) {
-            if (toPrerender.size < prerenderLimit) {
-              prerender(hrefFn ? hrefFn(entry) : entry.href).catch(err => {
-                if (options.onError) {
-                  options.onError(err);
-                } else {
-                  throw err;
-                }
-              });
-              return;
-            }
+          if ((shouldPrerenderAndPrefetch || shouldOnlyPrerender) && toPrerender.size < prerenderLimit) {
+            prerender(hrefFn ? hrefFn(entry) : entry.href).catch(err => {
+              if (options.onError) {
+                options.onError(err);
+              } else {
+                throw err;
+              }
+            });
+
+            return;
           }
 
           // Do not prefetch if will match/exceed limit and user has not switched to shouldOnlyPrerender mode
           if (toPrefetch.size < limit && !shouldOnlyPrerender) {
             toAdd(() => {
               prefetch(hrefFn ? hrefFn(entry) : entry.href, options.priority).then(isDone).catch(err => {
-                isDone(); if (options.onError) options.onError(err);
+                isDone();
+                if (options.onError) options.onError(err);
               });
             });
           }
@@ -169,18 +170,16 @@ export function listen(options) {
 
   timeoutFn(() => {
     // Find all links & Connect them to IO if allowed
-    let elementsToListen;
-    if (options.el && options.el.length && options.el.length > 0 && options.el[0].nodeName == 'A') {
-      elementsToListen = options.el;
-    } else {
-      elementsToListen = (options.el || document).querySelectorAll('a');
-    }
+    const elementsToListen = options.el && options.el.length && options.el.length > 0 && options.el[0].nodeName === 'A' ?
+      options.el :
+      (options.el || document).querySelectorAll('a');
+
     elementsToListen.forEach(link => {
       // If the anchor matches a permitted origin
       // ~> A `[]` or `true` means everything is allowed
       if (!allowed.length || allowed.includes(link.hostname)) {
         // If there are any filters, the link must not match any of them
-        isIgnored(link, ignores) || observer.observe(link);
+        if (!isIgnored(link, ignores)) observer.observe(link);
       }
     });
   }, {
@@ -199,13 +198,12 @@ export function listen(options) {
 * Prefetch a given URL with an optional preferred fetch priority
 * @param {String} url - the URL to fetch
 * @param {Boolean} [isPriority] - if is "high" priority
-* @param {Object} [conn] - navigator.connection (internal)
 * @return {Object} a Promise
 */
-export function prefetch(url, isPriority, conn) {
+export function prefetch(url, isPriority) {
   const chkConn = checkConnection(navigator.connection);
   if (chkConn instanceof Error) {
-    return Promise.reject(new Error('Cannot prefetch, '+chkConn.message));
+    return Promise.reject(new Error(`Cannot prefetch, ${chkConn.message}`));
   }
 
   if (toPrerender.size > 0 && !shouldPrerenderAndPrefetch) {
@@ -215,15 +213,15 @@ export function prefetch(url, isPriority, conn) {
   // Dev must supply own catch()
   return Promise.all(
       [].concat(url).map(str => {
-        if (!toPrefetch.has(str)) {
+        if (toPrefetch.has(str)) return [];
+
         // Add it now, regardless of its success
         // ~> so that we don't repeat broken links
-          toPrefetch.add(str);
+        toPrefetch.add(str);
 
-          return (isPriority ? priority : supported)(
-              new URL(str, location.href).toString(),
-          );
-        }
+        return (isPriority ? priority : supported)(
+            new URL(str, location.href).toString(),
+        );
       }),
   );
 }
@@ -231,13 +229,12 @@ export function prefetch(url, isPriority, conn) {
 /**
 * Prerender a given URL
 * @param {String} urls - the URL to fetch
-* @param {Object} [conn] - navigator.connection (internal)
 * @return {Object} a Promise
 */
-export function prerender(urls, conn) {
+export function prerender(urls) {
   const chkConn = checkConnection(navigator.connection);
   if (chkConn instanceof Error) {
-    return Promise.reject(new Error('Cannot prerender, '+chkConn.message));
+    return Promise.reject(new Error(`Cannot prerender, ${chkConn.message}`));
   }
 
   // prerendering preconditions:
@@ -255,7 +252,7 @@ export function prerender(urls, conn) {
   // 3) whether it's a same origin url,
   for (const url of [].concat(urls)) {
     if (!isSameOrigin(url)) {
-      return Promise.reject(new Error('Only same origin URLs are allowed: ' + url));
+      return Promise.reject(new Error(`Only same origin URLs are allowed: ${url}`));
     }
 
     toPrerender.add(url);
@@ -267,5 +264,5 @@ export function prerender(urls, conn) {
   }
 
   const addSpecRules = addSpeculationRules(toPrerender);
-  return (addSpecRules === true) ? Promise.resolve() : Promise.reject(addSpecRules);
+  return addSpecRules === true ? Promise.resolve() : Promise.reject(addSpecRules);
 }

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -34,17 +34,17 @@ function hasPrefetch(link) {
  * @return {Object} a Promise
  */
 function viaDOM(url) {
-  return new Promise((res, rej, link) => {
-    link = document.createElement(`link`);
-    link.rel = `prefetch`;
+  return new Promise((resolve, reject, link) => {
+    link = document.createElement('link');
+    link.rel = 'prefetch';
     link.href = url;
 
-    link.onload = res;
-    link.onerror = rej;
+    link.onload = resolve;
+    link.onerror = reject;
 
     document.head.appendChild(link);
   });
-};
+}
 
 /**
  * Fetches a given URL using XMLHttpRequest
@@ -52,18 +52,21 @@ function viaDOM(url) {
  * @return {Object} a Promise
  */
 function viaXHR(url) {
-  return new Promise((res, rej, req) => {
-    req = new XMLHttpRequest();
+  return new Promise((resolve, reject, request) => {
+    request = new XMLHttpRequest();
 
-    req.open(`GET`, url, req.withCredentials=true);
+    request.open('GET', url, request.withCredentials = true);
 
-    req.onload = () => {
-      // TODO Fix me
-      // eslint-disable-next-line prefer-promise-reject-errors
-      (req.status === 200) ? res() : rej();
+    request.onload = () => {
+      if (request.status === 200) {
+        resolve();
+      } else {
+        // eslint-disable-next-line prefer-promise-reject-errors
+        reject();
+      }
     };
 
-    req.send();
+    request.send();
   });
 }
 
@@ -81,7 +84,7 @@ export function priority(url) {
   //
   // As of 2018, fetch() is high-priority in Chrome
   // and medium-priority in Safari.
-  return window.fetch ? fetch(url, {credentials: `include`}) : viaXHR(url);
+  return window.fetch ? fetch(url, {credentials: 'include'}) : viaXHR(url);
 }
 
 export const supported = hasPrefetch() ? viaDOM : viaXHR;

--- a/src/prerender.mjs
+++ b/src/prerender.mjs
@@ -33,7 +33,7 @@ export function isSameOrigin(str) {
 export function addSpeculationRules(urlsToPrerender) {
   const specScript = document.createElement('script');
   specScript.type = 'speculationrules';
-  specScript.text = '{"prerender":[{"source": "list","urls": ["'+Array.from(urlsToPrerender).join('","')+'"]}]}';
+  specScript.text = `{"prerender":[{"source": "list","urls": ["${Array.from(urlsToPrerender).join('","')}"]}]}`;
   try {
     document.head.appendChild(specScript);
   } catch (e) {

--- a/src/react-chunks.js
+++ b/src/react-chunks.js
@@ -16,7 +16,7 @@
 
 import React, {useEffect, useRef, useState} from 'react';
 import rmanifest from 'route-manifest';
-import {listen} from './quicklink';
+import {listen} from './quicklink.js';
 
 const useIntersect = ({root = null, rootMargin, threshold = 0} = {}) => {
   const [entry, updateEntry] = useState({});
@@ -62,7 +62,7 @@ const withQuicklink = (Component, options = {}) => {
   // eslint-disable-next-line react/display-name
   return props => {
     const [ref, entry] = useIntersect({root: document.body.parentElement});
-    const intersectionRatio = entry.intersectionRatio;
+    const {intersectionRatio} = entry;
 
     useEffect(() => {
       options.prefetchChunks = prefetchChunks;

--- a/src/request-idle-callback.mjs
+++ b/src/request-idle-callback.mjs
@@ -18,10 +18,10 @@
 const requestIdleCallback = window.requestIdleCallback ||
   function (cb) {
     const start = Date.now();
-    return setTimeout(function () {
+    return setTimeout(() => {
       cb({
         didTimeout: false,
-        timeRemaining: function () {
+        timeRemaining() {
           return Math.max(0, 50 - (Date.now() - start));
         },
       });

--- a/test/quicklink.spec.js
+++ b/test/quicklink.spec.js
@@ -6,7 +6,7 @@ const host = 'http://127.0.0.1:8080';
 const server = `${host}/test`;
 const mainSuite = suite('quicklink tests');
 
-const sleep = ms => new Promise(r => setTimeout(r, ms));
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const puppeteerOptions = {
   headless: true,
@@ -103,10 +103,9 @@ mainSuite('should only prefetch links if allowed in origins list', async () => {
     responseURLs.push(resp.url());
   });
   await page.goto(`${server}/test-allow-origin.html`);
-
   await sleep(1000);
-
   assert.equal(Array.isArray(responseURLs), true);
+
   // => origins: ['github.githubassets.com']
   assert.equal(responseURLs.includes(`${server}/2.html`), false);
   assert.equal(responseURLs.includes('https://example.com/1.html'), true);
@@ -119,10 +118,9 @@ mainSuite('should prefetch all links when allowing all origins', async () => {
     responseURLs.push(resp.url());
   });
   await page.goto(`${server}/test-allow-origin-all.html`);
-
   await sleep(1000);
-
   assert.equal(Array.isArray(responseURLs), true);
+
   // => origins: true
   assert.equal(responseURLs.includes(`${server}/2.html`), true);
   assert.equal(responseURLs.includes('https://google.com/'), true);
@@ -137,9 +135,9 @@ mainSuite('should only prefetch links of same origin (default)', async () => {
     responseURLs.push(resp.url());
   });
   await page.goto(`${server}/test-same-origin.html`);
-
   await sleep(1000);
   assert.equal(Array.isArray(responseURLs), true);
+
   // => origins: [location.hostname] (default)
   assert.equal(responseURLs.includes(`${server}/2.html`), true);
   assert.equal(responseURLs.includes('https://example.com/1.html'), false);
@@ -152,9 +150,9 @@ mainSuite('should only prefetch links after ignore patterns allowed it', async (
     responseURLs.push(resp.url());
   });
   await page.goto(`${server}/test-ignore-basic.html`);
-
   await sleep(1000);
   assert.equal(Array.isArray(responseURLs), true);
+
   // => origins: [location.hostname] (default)
   // => ignores: /2.html/
   // via ignores
@@ -171,9 +169,9 @@ mainSuite('should only prefetch links after ignore patterns allowed it (multiple
     responseURLs.push(resp.url());
   });
   await page.goto(`${server}/test-ignore-multiple.html`);
-
   await sleep(1000);
   assert.equal(Array.isArray(responseURLs), true);
+
   // => origins: true (all)
   // => ignores: [...]
   assert.equal(responseURLs.includes(`${server}/2.html`), true);
@@ -265,9 +263,10 @@ mainSuite('should respect the `throttle` concurrency', async () => {
   await page.setRequestInterception(true);
 
   page.on('request', async req => {
-    if (/test\/\d+\.html$/i.test(req.url())) {
+    const url = req.url();
+    if (/test\/\d+\.html$/i.test(url)) {
       await sleep(100);
-      URLs.push(req.url());
+      URLs.push(url);
       return req.respond({status: 200});
     }
 
@@ -337,7 +336,6 @@ mainSuite('should consider threshold option before prefetching (UMD)', async () 
   page.on('response', resp => {
     responseURLs.push(resp.url());
   });
-
   await page.goto(`${server}/test-threshold.html`);
   await page.setViewport({
     width: 1000,


### PR DESCRIPTION
The 3rd parameter in `prerender` and `prefetch` are moot after https://github.com/GoogleChromeLabs/quicklink/commit/383e4955b9264716a61ce11a7e1931584f0b59b4, but I'll let you verify @addyosmani.

If you think we should bring it back let me know.

This patch saves a few bytes.

BTW Happy to revert any changes if you prefer the old way. :)

Non-whitespace diff: https://github.com/GoogleChromeLabs/quicklink/pull/312/files?w=1