### PR TITLE
tests: remove IntersectionObserver script and format HTML files

### DIFF
--- a/demos/basic.html
+++ b/demos/basic.html
@@ -6,7 +6,6 @@
   <title>Basic demo</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="../test/main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>

--- a/demos/hrefFn/hrefFn_demo.html
+++ b/demos/hrefFn/hrefFn_demo.html
@@ -6,8 +6,8 @@
   <title>Basic demo</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="../../test/main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
+
 <body>
   <div class="screen">
     <h1>Basic demo</h1>
@@ -27,30 +27,31 @@
       el: document.querySelector('div.screen'),
       // hrefFn will prevent quicklink to prefetch the "href" attribute URL
       // and the returned value will be prefetched as a result.
-      hrefFn: function(element) {
-        return element.href.replace('html','json');
+      hrefFn(element) {
+        return element.href.replace('html', 'json');
       }
     });
   </script>
 
   <script>
     // Simple SPA-like page transition for demo purposes
-    var container = document.querySelector('div.screen'),
-      link = container.querySelector('a'),
-      title = container.querySelector('h1'),
-      paragraph = container.querySelector('p');
+    const container = document.querySelector('div.screen');
+    const link = container.querySelector('a');
+    const title = container.querySelector('h1');
+    const paragraph = container.querySelector('p');
 
-    link.addEventListener('click', function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      var href = e.target.href.replace('html','json');
+    link.addEventListener('click', event => {
+      event.preventDefault();
+      event.stopPropagation();
+      const href = event.target.href.replace('html', 'json');
       fetch(href)
-      .then(response => response.json())
-      .then(data => {
-        title.innerHTML = document.title = data.title;
-        paragraph.innerHTML = data.description;
-      });
+        .then(response => response.json())
+        .then(data => {
+          title.innerHTML = document.title = data.title;
+          paragraph.innerHTML = data.description;
+        });
     });
   </script>
 </body>
+
 </html>

--- a/demos/network-idle.html
+++ b/demos/network-idle.html
@@ -6,7 +6,6 @@
   <title>network-idle-callback demo</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="../test/main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', function () {

--- a/test/index.html
+++ b/test/index.html
@@ -1,14 +1,11 @@
 <!doctype html>
 <html lang="en">
-
 <head>
   <meta charset="utf-8">
   <title>Prefetch experiments</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
-
 <body>
   <a href="1.html">Link 1</a>
   <a href="2.html">Link 2</a>
@@ -31,5 +28,4 @@
     // });
   </script>
 </body>
-
 </html>

--- a/test/quicklink.spec.js
+++ b/test/quicklink.spec.js
@@ -191,8 +191,8 @@ describe('quicklink tests', () => {
     await page.goto(`${server}/test-prefetch-multiple.html`);
     await sleep(1000);
 
-    // don't care about first 4 URLs (markup)
-    const ours = responseURLs.slice(4);
+    // don't care about first 3 URLs (markup)
+    const ours = responseURLs.slice(3);
 
     assert.equal(ours.length, 3);
     assert.equal(ours.includes(`${server}/2.html`), true);
@@ -208,8 +208,8 @@ describe('quicklink tests', () => {
     await page.goto(`${server}/test-prefetch-duplicate.html`);
     await sleep(1000);
 
-    // don't care about first 4 URLs (markup)
-    const ours = responseURLs.slice(4);
+    // don't care about first 3 URLs (markup)
+    const ours = responseURLs.slice(3);
 
     assert.equal(ours.length, 1);
     assert.equal(ours.includes(`${server}/2.html`), true);
@@ -237,8 +237,8 @@ describe('quicklink tests', () => {
     await page.goto(`${server}/test-limit.html`);
     await sleep(1000);
 
-    // don't care about first 4 URLs (markup)
-    const ours = responseURLs.slice(4);
+    // don't care about first 3 URLs (markup)
+    const ours = responseURLs.slice(3);
 
     assert.equal(ours.length, 1);
     assert.equal(ours.includes(`${server}/1.html`), true);
@@ -283,8 +283,8 @@ describe('quicklink tests', () => {
     await page.goto(`${server}/test-custom-href-function.html`);
     await sleep(1000);
 
-    // don't care about first 4 URLs (markup)
-    const ours = responseURLs.slice(4);
+    // don't care about first 3 URLs (markup)
+    const ours = responseURLs.slice(3);
     assert.equal(ours.includes(`https://example.com/?url=${server}/1.html`), true);
     assert.equal(ours.includes(`https://example.com/?url=${server}/2.html`), true);
     assert.equal(ours.includes(`https://example.com/?url=${server}/3.html`), true);

--- a/test/rmanifest.json
+++ b/test/rmanifest.json
@@ -1,37 +1,52 @@
 {
-  "/about": [{
-    "type": "style",
-    "href": "/test/static/css/about.00ec0d84.chunk.css"
-  }, {
-    "type": "script",
-    "href": "/test/static/js/about.921ebc84.chunk.js"
-  }],
-  "/blog": [{
-    "type": "style",
-    "href": "/test/static/css/blog.2a8b6ab6.chunk.css"
-  }, {
-    "type": "script",
-    "href": "/test/static/js/blog.1dcce8a6.chunk.js"
-  }],
-  "/": [{
-    "type": "style",
-    "href": "/test/static/css/home.6d953f22.chunk.css"
-  }, {
-    "type": "script",
-    "href": "/test/static/js/home.14835906.chunk.js"
-  }, {
-    "type": "image",
-    "href": "/test/static/media/video.b9b6e9e1.svg"
-  }],
-  "/blog/:title": [{
-    "type": "style",
-    "href": "/test/static/css/article.cb6f97df.chunk.css"
-  }, {
-    "type": "script",
-    "href": "/test/static/js/article.cb6f97df.chunk.js"
-  }],
-  "*": [{
-    "type": "script",
-    "href": "/test/static/js/6.7f61b1a1.chunk.js"
-  }]
+  "/about": [
+    {
+      "type": "style",
+      "href": "/test/static/css/about.00ec0d84.chunk.css"
+    },
+    {
+      "type": "script",
+      "href": "/test/static/js/about.921ebc84.chunk.js"
+    }
+  ],
+  "/blog": [
+    {
+      "type": "style",
+      "href": "/test/static/css/blog.2a8b6ab6.chunk.css"
+    },
+    {
+      "type": "script",
+      "href": "/test/static/js/blog.1dcce8a6.chunk.js"
+    }
+  ],
+  "/": [
+    {
+      "type": "style",
+      "href": "/test/static/css/home.6d953f22.chunk.css"
+    },
+    {
+      "type": "script",
+      "href": "/test/static/js/home.14835906.chunk.js"
+    },
+    {
+      "type": "image",
+      "href": "/test/static/media/video.b9b6e9e1.svg"
+    }
+  ],
+  "/blog/:title": [
+    {
+      "type": "style",
+      "href": "/test/static/css/article.cb6f97df.chunk.css"
+    },
+    {
+      "type": "script",
+      "href": "/test/static/js/article.cb6f97df.chunk.js"
+    }
+  ],
+  "*": [
+    {
+      "type": "script",
+      "href": "/test/static/js/6.7f61b1a1.chunk.js"
+    }
+  ]
 }

--- a/test/test-allow-origin-all.html
+++ b/test/test-allow-origin-all.html
@@ -2,28 +2,27 @@
 <html lang="en">
 
 <head>
-    <meta charset="utf-8">
-    <title>Prefetch: Allow All Origins</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="main.css">
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
+  <meta charset="utf-8">
+  <title>Prefetch: Allow All Origins</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="main.css">
 </head>
 
 <body>
-    <a href="https://example.com/1.html">Link 1</a>
-    <a href="2.html">Link 2</a>
-    <a href="https://google.com/">Link 3</a>
-    <a href="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">Spinner</a>
-    <section id="stuff">
-        <a href="main.css">CSS</a>
-    </section>
-    <a href="4.html" style="position:absolute;margin-top:900px;">Link 4</a>
-    <script src="../dist/quicklink.umd.js"></script>
-    <script>
-        quicklink.listen({
-            origins: true
-        });
-    </script>
+  <a href="https://example.com/1.html">Link 1</a>
+  <a href="2.html">Link 2</a>
+  <a href="https://google.com/">Link 3</a>
+  <a href="https://github.githubassets.com/images/spinners/octocat-spinner-32.gif">Spinner</a>
+  <section id="stuff">
+    <a href="main.css">CSS</a>
+  </section>
+  <a href="4.html" style="position:absolute;margin-top:900px;">Link 4</a>
+  <script src="../dist/quicklink.umd.js"></script>
+  <script>
+    quicklink.listen({
+      origins: true
+    });
+  </script>
 </body>
 
 </html>

--- a/test/test-allow-origin.html
+++ b/test/test-allow-origin.html
@@ -6,7 +6,6 @@
   <title>Prefetch: Allowed Origins</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>

--- a/test/test-basic-usage.html
+++ b/test/test-basic-usage.html
@@ -6,7 +6,6 @@
   <title>Prefetch: Basic Usage</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>

--- a/test/test-custom-dom-source.html
+++ b/test/test-custom-dom-source.html
@@ -6,7 +6,6 @@
   <title>Prefetch: Custom DOM source</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>

--- a/test/test-custom-href-function.html
+++ b/test/test-custom-href-function.html
@@ -6,7 +6,6 @@
   <title>Prefetch: Custom function to build the URL.</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>
@@ -17,7 +16,7 @@
   <script src="../dist/quicklink.umd.js"></script>
   <script>
     quicklink.listen({
-        hrefFn: (entry) => ( `https://example.com/?url=${entry.href}` ),
+      hrefFn: (entry) => (`https://example.com/?url=${entry.href}`),
     });
   </script>
 </body>

--- a/test/test-delay.html
+++ b/test/test-delay.html
@@ -1,24 +1,22 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title>Prefetch: Basic Usage</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="main.css">
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
-  </head>
-
-  <body>
-    <a href="1.html">Link 1</a>
-    <a href="2.html">Link 2</a>
-    <a href="3.html">Link 3</a>
-    <section id="stuff">
-      <a href="main.css">CSS</a>
-    </section>
-    <a href="4.html" style="position: absolute; margin-top: 900px">Link 4</a>
-    <script src="../dist/quicklink.umd.js"></script>
-    <script>
-      quicklink.listen({ delay: 200 });
-    </script>
-  </body>
+<head>
+  <meta charset="utf-8">
+  <title>Prefetch: Basic Usage</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="main.css">
+</head>
+<body>
+  <a href="1.html">Link 1</a>
+  <a href="2.html">Link 2</a>
+  <a href="3.html">Link 3</a>
+  <section id="stuff">
+    <a href="main.css">CSS</a>
+  </section>
+  <a href="4.html" style="position: absolute; margin-top: 900px">Link 4</a>
+  <script src="../dist/quicklink.umd.js"></script>
+  <script>
+    quicklink.listen({ delay: 200 });
+  </script>
+</body>
 </html>

--- a/test/test-es-modules.html
+++ b/test/test-es-modules.html
@@ -6,7 +6,6 @@
   <title>Prefetch: ES Modules</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>

--- a/test/test-ignore-basic.html
+++ b/test/test-ignore-basic.html
@@ -6,7 +6,6 @@
   <title>Prefetch: Ignore Basic</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>

--- a/test/test-ignore-multiple.html
+++ b/test/test-ignore-multiple.html
@@ -6,7 +6,6 @@
   <title>Prefetch: Ignore Multiple</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>

--- a/test/test-limit.html
+++ b/test/test-limit.html
@@ -6,7 +6,6 @@
   <title>Prefetch: Basic Usage</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>

--- a/test/test-node-list.html
+++ b/test/test-node-list.html
@@ -1,27 +1,28 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title>Prefetch: NodeList case</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="main.css">
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
-  </head>
 
-  <body>
-    <a href="1.html">Link 1</a>
-    <section id="stuff1">
-      <a href="2.html" class="linksToPrefetch">Link 2</a>
-    </section>
-    <section id="stuff2">
-      <a href="3.html" class="linksToPrefetch">Link 3</a>
-    </section>
-    <a href="4.html" style="position: absolute; margin-top: 900px;">Link 4</a>
-    <script src="../dist/quicklink.umd.js"></script>
-    <script>
-      quicklink.listen({
-        el: document.querySelectorAll('a.linksToPrefetch'),
-      });
-    </script>
-  </body>
+<head>
+  <meta charset="utf-8">
+  <title>Prefetch: NodeList case</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="main.css">
+</head>
+
+<body>
+  <a href="1.html">Link 1</a>
+  <section id="stuff1">
+    <a href="2.html" class="linksToPrefetch">Link 2</a>
+  </section>
+  <section id="stuff2">
+    <a href="3.html" class="linksToPrefetch">Link 3</a>
+  </section>
+  <a href="4.html" style="position: absolute; margin-top: 900px;">Link 4</a>
+  <script src="../dist/quicklink.umd.js"></script>
+  <script>
+    quicklink.listen({
+      el: document.querySelectorAll('a.linksToPrefetch'),
+    });
+  </script>
+</body>
+
 </html>

--- a/test/test-prefetch-chunks.html
+++ b/test/test-prefetch-chunks.html
@@ -1,11 +1,11 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <title>Prefetch: Chunk URL list</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>
@@ -55,4 +55,5 @@
     listenAfterFetchingRmanifest();
   </script>
 </body>
+
 </html>

--- a/test/test-prefetch-duplicate-shared.html
+++ b/test/test-prefetch-duplicate-shared.html
@@ -1,11 +1,11 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <title>Prefetch: Static URL list</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>
@@ -23,4 +23,5 @@
     }, 10);
   </script>
 </body>
+
 </html>

--- a/test/test-prefetch-duplicate.html
+++ b/test/test-prefetch-duplicate.html
@@ -1,11 +1,11 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <title>Prefetch: Static URL list</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>
@@ -21,4 +21,5 @@
     quicklink.prefetch(['2.html', '2.html', '2.html']);
   </script>
 </body>
+
 </html>

--- a/test/test-prefetch-multiple.html
+++ b/test/test-prefetch-multiple.html
@@ -1,11 +1,11 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <title>Prefetch: Static URL list</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>
@@ -21,4 +21,5 @@
     quicklink.prefetch(['2.html', '3.html', '4.html']);
   </script>
 </body>
+
 </html>

--- a/test/test-prefetch-single.html
+++ b/test/test-prefetch-single.html
@@ -1,11 +1,11 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <title>Prefetch: Static URL list</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>
@@ -21,4 +21,5 @@
     quicklink.prefetch('2.html');
   </script>
 </body>
+
 </html>

--- a/test/test-prerender-andPrefetch.html
+++ b/test/test-prerender-andPrefetch.html
@@ -6,7 +6,6 @@
   <title>Prefetch: Basic Usage</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>
@@ -19,7 +18,7 @@
   <a href="4.html" style="position:absolute;margin-top:900px;">Link 4</a>
   <script src="../dist/quicklink.umd.js"></script>
   <script>
-    quicklink.listen({prerenderAndPrefetch: true});
+    quicklink.listen({ prerenderAndPrefetch: true });
   </script>
 </body>
 

--- a/test/test-prerender-only.html
+++ b/test/test-prerender-only.html
@@ -6,7 +6,6 @@
   <title>Prefetch: Basic Usage</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>
@@ -19,7 +18,7 @@
   <a href="4.html" style="position:absolute;margin-top:900px;">Link 4</a>
   <script src="../dist/quicklink.umd.js"></script>
   <script>
-    quicklink.listen({prerender: true});
+    quicklink.listen({ prerender: true });
   </script>
 </body>
 

--- a/test/test-prerender-wrapper-multiple.html
+++ b/test/test-prerender-wrapper-multiple.html
@@ -6,7 +6,6 @@
   <title>Prefetch: Basic Usage</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>
@@ -19,7 +18,7 @@
   <a href="4.html" style="position:absolute;margin-top:900px;">Link 4</a>
   <script src="../dist/quicklink.umd.js"></script>
   <script>
-    quicklink.prerender(['1.html','2.html','3.html','4.html']);
+    quicklink.prerender(['1.html', '2.html', '3.html', '4.html']);
   </script>
 </body>
 

--- a/test/test-prerender-wrapper-single.html
+++ b/test/test-prerender-wrapper-single.html
@@ -6,7 +6,6 @@
   <title>Prefetch: Basic Usage</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>

--- a/test/test-same-origin.html
+++ b/test/test-same-origin.html
@@ -6,7 +6,6 @@
   <title>Prefetch: Same Origin</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>

--- a/test/test-threshold.html
+++ b/test/test-threshold.html
@@ -24,8 +24,8 @@
       background: #ccc;
       text-align: center;
     }
+
   </style>
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>
@@ -45,7 +45,7 @@
   </ul>
   <script src="../dist/quicklink.umd.js"></script>
   <script>
-    quicklink.listen({threshold: 0.5});
+    quicklink.listen({ threshold: 0.5 });
   </script>
 </body>
 

--- a/test/test-throttle.html
+++ b/test/test-throttle.html
@@ -6,7 +6,6 @@
   <title>Prefetch: Basic Usage</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="main.css">
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 </head>
 
 <body>


### PR DESCRIPTION
If we still need the polyfill let me know and I'll just keep the formatting changes.

Non-whitespace diff: https://github.com/GoogleChromeLabs/quicklink/pull/316/files?w=1