### PR TITLE
Replace prepare with `prepublishOnly`

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -36,5 +36,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build
+        run: npm run build
+
       - name: Run size-limit
         run: npm run size

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build-plugin": "microbundle src/chunks.mjs --no-sourcemap --external none -o dist/react",
     "build-react-chunks": "babel src/react-chunks.js --out-file dist/react/hoc.js",
     "build-all": "npm-run-all --parallel build build-plugin build-react-chunks",
-    "prepare": "npm run build",
+    "prepublishonly": "npm run build-all",
     "size": "size-limit",
     "changelog": "npm run conventional-changelog -i CHANGELOG.md -s -r 0",
     "release": "cross-env-shell \"npm run build-all && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags\""


### PR DESCRIPTION
@addyosmani I believe this is what was the original intention? Before, prepare ran after npm install which was annoying.

Feel free to close if the PR is wrong :)