### PR TITLE
site: Backport fixes from README

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,3 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
-
-[api.njk]
-trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[api.njk]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ A "reset" function is returned, which will empty the active `IntersectionObserve
 
 #### options.prerender
 
-Type: `Boolean`  
-Default: `false`
+* Type: `Boolean`
+* Default: `false`
 
 Whether to switch from the default prefetching mode to the prerendering mode for the links inside the viewport.
 
@@ -129,43 +129,43 @@ Whether to switch from the default prefetching mode to the prerendering mode for
 
 #### options.delay
 
-Type: `Number`  
-Default: `0`
+* Type: `Number`
+* Default: `0`
 
 The _amount of time_ each link needs to stay inside the viewport before being prefetched, in milliseconds.
 
 #### options.el
 
-Type: `HTMLElement|NodeList<A>`  
-Default: `document.body`
+* Type: `HTMLElement|NodeList<A>`
+* Default: `document.body`
 
 The DOM element to observe for in-viewport links to prefetch or the NodeList of Anchor Elements.
 
 #### options.limit
 
-Type: `Number`  
-Default: `Infinity`
+* Type: `Number`
+* Default: `Infinity`
 
 The _total_ requests that can be prefetched while observing the `options.el` container.
 
 #### options.threshold
 
-Type: `Number`  
-Default: `0`
+* Type: `Number`
+* Default: `0`
 
 The _area percentage_ of each link that must have entered the viewport to be fetched, in its decimal form (e.g. 0.25 = 25%).
 
 #### options.throttle
 
-Type: `Number`  
-Default: `Infinity`
+* Type: `Number`
+* Default: `Infinity`
 
 The _concurrency limit_ for simultaneous requests while observing the `options.el` container.
 
 #### options.timeout
 
-Type: `Number`  
-Default: `2000`
+* Type: `Number`
+* Default: `2000`
 
 The `requestIdleCallback` timeout, in milliseconds.
 
@@ -173,18 +173,19 @@ The `requestIdleCallback` timeout, in milliseconds.
 
 #### options.timeoutFn
 
-Type: `Function`  
-Default: `requestIdleCallback`
+* Type: `Function`
+* Default: `requestIdleCallback`
 
-A function used for specifying a `timeout` delay.  
+A function used for specifying a `timeout` delay.
+
 This can be swapped out for a custom function like [networkIdleCallback](https://github.com/pastelsky/network-idle-callback) (see demos).
 
 By default, this uses [`requestIdleCallback`](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback) or the embedded polyfill.
 
 #### options.priority
 
-Type: `Boolean`  
-Default: `false`
+* Type: `Boolean`
+* Default: `false`
 
 Whether or not the URLs within the `options.el` container should be treated as high priority.
 
@@ -192,18 +193,19 @@ When `true`, quicklink will attempt to use the `fetch()` API if supported (rathe
 
 #### options.origins
 
-Type: `Array<String>`  
-Default: `[location.hostname]`
+* Type: `Array<String>`
+* Default: `[location.hostname]`
 
-A static array of URL hostnames that are allowed to be prefetched.  
+A static array of URL hostnames that are allowed to be prefetched.
+
 Defaults to the same domain origin, which prevents _any_ cross-origin requests.
 
 **Important:** An empty array (`[]`) allows **_all origins_** to be prefetched.
 
 #### options.ignores
 
-Type: `RegExp` or `Function` or `Array`  
-Default: `[]`
+* Type: `RegExp` or `Function` or `Array`
+* Default: `[]`
 
 Determine if a URL should be prefetched.
 
@@ -215,16 +217,17 @@ When a `RegExp` tests positive, a `Function` returns `true`, or an `Array` conta
 
 #### options.onError
 
-Type: `Function`  
-Default: None
+* Type: `Function`
+* Default: None
 
-An optional error handler that will receive any errors from prefetched requests.  
+An optional error handler that will receive any errors from prefetched requests.
+
 By default, these errors are silently ignored.
 
 #### options.hrefFn
 
-Type: `Function`  
-Default: None
+* Type: `Function`
+* Default: None
 
 An optional function to generate the URL to prefetch. It receives an [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) as the argument.
 
@@ -238,8 +241,8 @@ The `urls` provided are always passed through `Promise.all`, which means the res
 
 #### urls
 
-Type: `String` or `Array<String>`  
-Required: `true`
+* Type: `String` or `Array<String>`
+* Required: `true`
 
 One or many URLs to be prefetched.
 
@@ -247,10 +250,11 @@ One or many URLs to be prefetched.
 
 #### isPriority
 
-Type: `Boolean`  
-Default: `false`
+* Type: `Boolean`
+* Default: `false`
 
-Whether or not the URL(s) should be treated as "high priority" targets.  
+Whether or not the URL(s) should be treated as "high priority" targets.
+
 By default, calls to `prefetch()` are low priority.
 
 > **Note:** This behaves identically to `listen()`'s `priority` option.
@@ -263,8 +267,8 @@ Returns: `Promise`
 
 #### urls
 
-Type: `String` or `Array<String>`  
-Required: `true`
+* Type: `String` or `Array<String>`
+* Required: `true`
 
 One or many URLs to be prerendered.
 
@@ -449,7 +453,8 @@ Certain features have layered support:
 
 ## Using the prefetcher directly
 
-A `prefetch` method can be individually imported for use in other projects.  
+A `prefetch` method can be individually imported for use in other projects.
+
 This method includes the logic to respect Data Saver and 2G connections. It also issues requests thru `fetch()`, XHRs, or `link[rel=prefetch]` depending on (a) the `isPriority` value and (b) the current browser's support.
 
 After installing `quicklink` as a dependency, you can use it as follows:

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ A "reset" function is returned, which will empty the active `IntersectionObserve
 
 #### options.prerender
 
-Type: `Boolean`<br>
+Type: `Boolean`  
 Default: `false`
 
 Whether to switch from the default prefetching mode to the prerendering mode for the links inside the viewport.
@@ -129,42 +129,42 @@ Whether to switch from the default prefetching mode to the prerendering mode for
 
 #### options.delay
 
-Type: `Number`<br>
+Type: `Number`  
 Default: `0`
 
 The _amount of time_ each link needs to stay inside the viewport before being prefetched, in milliseconds.
 
 #### options.el
 
-Type: `HTMLElement|NodeList<A>`<br>
+Type: `HTMLElement|NodeList<A>`  
 Default: `document.body`
 
 The DOM element to observe for in-viewport links to prefetch or the NodeList of Anchor Elements.
 
 #### options.limit
 
-Type: `Number`<br>
+Type: `Number`  
 Default: `Infinity`
 
 The _total_ requests that can be prefetched while observing the `options.el` container.
 
 #### options.threshold
 
-Type: `Number`<br>
+Type: `Number`  
 Default: `0`
 
 The _area percentage_ of each link that must have entered the viewport to be fetched, in its decimal form (e.g. 0.25 = 25%).
 
 #### options.throttle
 
-Type: `Number`<br>
+Type: `Number`  
 Default: `Infinity`
 
 The _concurrency limit_ for simultaneous requests while observing the `options.el` container.
 
 #### options.timeout
 
-Type: `Number`<br>
+Type: `Number`  
 Default: `2000`
 
 The `requestIdleCallback` timeout, in milliseconds.
@@ -173,17 +173,17 @@ The `requestIdleCallback` timeout, in milliseconds.
 
 #### options.timeoutFn
 
-Type: `Function`<br>
+Type: `Function`  
 Default: `requestIdleCallback`
 
-A function used for specifying a `timeout` delay.<br>
+A function used for specifying a `timeout` delay.  
 This can be swapped out for a custom function like [networkIdleCallback](https://github.com/pastelsky/network-idle-callback) (see demos).
 
 By default, this uses [`requestIdleCallback`](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback) or the embedded polyfill.
 
 #### options.priority
 
-Type: `Boolean`<br>
+Type: `Boolean`  
 Default: `false`
 
 Whether or not the URLs within the `options.el` container should be treated as high priority.
@@ -192,17 +192,17 @@ When `true`, quicklink will attempt to use the `fetch()` API if supported (rathe
 
 #### options.origins
 
-Type: `Array<String>`<br>
+Type: `Array<String>`  
 Default: `[location.hostname]`
 
-A static array of URL hostnames that are allowed to be prefetched.<br>
+A static array of URL hostnames that are allowed to be prefetched.  
 Defaults to the same domain origin, which prevents _any_ cross-origin requests.
 
 **Important:** An empty array (`[]`) allows **_all origins_** to be prefetched.
 
 #### options.ignores
 
-Type: `RegExp` or `Function` or `Array`<br>
+Type: `RegExp` or `Function` or `Array`  
 Default: `[]`
 
 Determine if a URL should be prefetched.
@@ -215,15 +215,15 @@ When a `RegExp` tests positive, a `Function` returns `true`, or an `Array` conta
 
 #### options.onError
 
-Type: `Function`<br>
+Type: `Function`  
 Default: None
 
-An optional error handler that will receive any errors from prefetched requests.<br>
+An optional error handler that will receive any errors from prefetched requests.  
 By default, these errors are silently ignored.
 
 #### options.hrefFn
 
-Type: `Function`<br>
+Type: `Function`  
 Default: None
 
 An optional function to generate the URL to prefetch. It receives an [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) as the argument.
@@ -238,7 +238,7 @@ The `urls` provided are always passed through `Promise.all`, which means the res
 
 #### urls
 
-Type: `String` or `Array<String>`<br>
+Type: `String` or `Array<String>`  
 Required: `true`
 
 One or many URLs to be prefetched.
@@ -247,10 +247,10 @@ One or many URLs to be prefetched.
 
 #### isPriority
 
-Type: `Boolean`<br>
+Type: `Boolean`  
 Default: `false`
 
-Whether or not the URL(s) should be treated as "high priority" targets.<br>
+Whether or not the URL(s) should be treated as "high priority" targets.  
 By default, calls to `prefetch()` are low priority.
 
 > **Note:** This behaves identically to `listen()`'s `priority` option.
@@ -263,7 +263,7 @@ Returns: `Promise`
 
 #### urls
 
-Type: `String` or `Array<String>`<br>
+Type: `String` or `Array<String>`  
 Required: `true`
 
 One or many URLs to be prerendered.
@@ -449,7 +449,7 @@ Certain features have layered support:
 
 ## Using the prefetcher directly
 
-A `prefetch` method can be individually imported for use in other projects.<br>
+A `prefetch` method can be individually imported for use in other projects.  
 This method includes the logic to respect Data Saver and 2G connections. It also issues requests thru `fetch()`, XHRs, or `link[rel=prefetch]` depending on (a) the `isPriority` value and (b) the current browser's support.
 
 After installing `quicklink` as a dependency, you can use it as follows:

--- a/site/src/_includes/components/react.njk
+++ b/site/src/_includes/components/react.njk
@@ -27,7 +27,7 @@ Wrap your routes with the `withQuicklink()` HOC.
 Example:
 {% endmarkdownConvert %}
 
-{% highlight "js" %}
+{% highlight "jsx" %}
 import { withQuicklink } from 'quicklink/dist/react/hoc.js';
 
 const options = {

--- a/site/src/api.njk
+++ b/site/src/api.njk
@@ -13,44 +13,58 @@ bottomResource:
 ## API
 
 ### quicklink.listen(options)
+
 Returns: `Function`
 
 A "reset" function is returned, which will empty the active `IntersectionObserver` and the cache of URLs that have already been prefetched or prerendered. This can be used between page navigations and/or when significant DOM changes have occurred.
 
 #### options.prerender
-Type: `Boolean`<br>
+
+Type: `Boolean`  
 Default: `false`
 
 Whether to switch from the default prefetching mode to the prerendering mode for the links inside the viewport.
 
 > **Note:** The prerendering mode (when this option is set to true) will fallback to the prefetching mode if the browser does not support prerender.
 
-#### options.el
-Type: `HTMLElement`<br>
-Default: `document.body`
-
-The DOM element to observe for in-viewport links to prefetch.
-
 #### options.delay
-Type: `Number`<br>
+
+Type: `Number`  
 Default: `0`
 
 The _amount of time_ each link needs to stay inside the viewport before being prefetched, in milliseconds.
 
+#### options.el
+
+Type: `HTMLElement|NodeList<A>`  
+Default: `document.body`
+
+The DOM element to observe for in-viewport links to prefetch or the NodeList of Anchor Elements.
+
 #### options.limit
-Type: `Number`<br>
+
+Type: `Number`  
 Default: `Infinity`
 
 The _total_ requests that can be prefetched while observing the `options.el` container.
 
+#### options.threshold
+
+Type: `Number`  
+Default: `0`
+
+The _area percentage_ of each link that must have entered the viewport to be fetched, in its decimal form (e.g. 0.25 = 25%).
+
 #### options.throttle
-Type: `Number`<br>
+
+Type: `Number`  
 Default: `Infinity`
 
 The _concurrency limit_ for simultaneous requests while observing the `options.el` container.
 
 #### options.timeout
-Type: `Number`<br>
+
+Type: `Number`  
 Default: `2000`
 
 The `requestIdleCallback` timeout, in milliseconds.
@@ -58,16 +72,18 @@ The `requestIdleCallback` timeout, in milliseconds.
 > **Note:** The browser must be idle for the configured duration before prefetching.
 
 #### options.timeoutFn
-Type: `Function`<br>
+
+Type: `Function`  
 Default: `requestIdleCallback`
 
-A function used for specifying a `timeout` delay.<br>
+A function used for specifying a `timeout` delay.  
 This can be swapped out for a custom function like [networkIdleCallback](https://github.com/pastelsky/network-idle-callback) (see demos).
 
 By default, this uses [`requestIdleCallback`](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback) or the embedded polyfill.
 
 #### options.priority
-Type: `Boolean`<br>
+
+Type: `Boolean`  
 Default: `false`
 
 Whether or not the URLs within the `options.el` container should be treated as high priority.
@@ -75,16 +91,18 @@ Whether or not the URLs within the `options.el` container should be treated as h
 When `true`, quicklink will attempt to use the `fetch()` API if supported (rather than `link[rel=prefetch]`).
 
 #### options.origins
-Type: `Array<String>`<br>
+
+Type: `Array<String>`  
 Default: `[location.hostname]`
 
-A static array of URL hostnames that are allowed to be prefetched.<br>
+A static array of URL hostnames that are allowed to be prefetched.  
 Defaults to the same domain origin, which prevents _any_ cross-origin requests.
 
-**Important:** An empty array (`[]`) allows ***all origins*** to be prefetched.
+**Important:** An empty array (`[]`) allows **_all origins_** to be prefetched.
 
 #### options.ignores
-Type: `RegExp` or `Function` or `Array`<br>
+
+Type: `RegExp` or `Function` or `Array`  
 Default: `[]`
 
 Determine if a URL should be prefetched.
@@ -96,14 +114,22 @@ When a `RegExp` tests positive, a `Function` returns `true`, or an `Array` conta
 > **Important:** This logic is executed _after_ origin matching!
 
 #### options.onError
-Type: `Function`<br>
+
+Type: `Function`  
 Default: None
 
-An optional error handler that will receive any errors from prefetched requests.<br>
+An optional error handler that will receive any errors from prefetched requests.  
 By default, these errors are silently ignored.
 
+#### options.hrefFn
+
+Type: `Function`  
+Default: None
+
+An optional function to generate the URL to prefetch. It receives an [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) as the argument.
 
 ### quicklink.prefetch(urls, isPriority)
+
 Returns: `Promise`
 
 The `urls` provided are always passed through `Promise.all`, which means the result will always resolve to an Array.
@@ -111,7 +137,8 @@ The `urls` provided are always passed through `Promise.all`, which means the res
 > **Important:** You much `catch` you own request error(s).
 
 #### urls
-Type: `String` or `Array<String>`<br>
+
+Type: `String` or `Array<String>`  
 Required: `true`
 
 One or many URLs to be prefetched.
@@ -119,21 +146,24 @@ One or many URLs to be prefetched.
 > **Note:** Each `url` value is resolved from the current location.
 
 #### isPriority
-Type: `Boolean`<br>
+
+Type: `Boolean`  
 Default: `false`
 
-Whether or not the URL(s) should be treated as "high priority" targets.<br>
+Whether or not the URL(s) should be treated as "high priority" targets.  
 By default, calls to `prefetch()` are low priority.
 
 > **Note:** This behaves identically to `listen()`'s `priority` option.
 
 ### quicklink.prerender(urls)
+
 Returns: `Promise`
 
 > **Important:** You much `catch` you own request error(s).
 
 #### urls
-Type: `String` or `Array<String>`<br>
+
+Type: `String` or `Array<String>`  
 Required: `true`
 
 One or many URLs to be prerendered.
@@ -144,8 +174,9 @@ One or many URLs to be prerendered.
 
 `quicklink`:
 
-* Includes a very small fallback for [requestIdleCallback](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback)
-* Requires `IntersectionObserver` to be supported (see [CanIUse](https://caniuse.com/#feat=intersectionobserver)). We recommend conditionally polyfilling this feature with a service like Polyfill.io:
+- Includes a very small fallback for [requestIdleCallback](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback)
+- Requires `IntersectionObserver` to be supported (see [CanIUse](https://caniuse.com/#feat=intersectionobserver)). We recommend conditionally polyfilling this feature with a service like Polyfill.io:
+
 {% endmarkdownConvert %}
 {% highlight "html" %}
 <script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
@@ -300,7 +331,7 @@ Certain features have layered support:
 
 ## Using the prefetcher directly
 
-A `prefetch` method can be individually imported for use in other projects.<br>
+A `prefetch` method can be individually imported for use in other projects.  
 This method includes the logic to respect Data Saver and 2G connections. It also issues requests thru `fetch()`, XHRs, or `link[rel=prefetch]` depending on (a) the `isPriority` value and (b) the current browser's support.
 
 After installing `quicklink` as a dependency, you can use it as follows:

--- a/site/src/api.njk
+++ b/site/src/api.njk
@@ -20,8 +20,8 @@ A "reset" function is returned, which will empty the active `IntersectionObserve
 
 #### options.prerender
 
-Type: `Boolean`  
-Default: `false`
+* Type: `Boolean`
+* Default: `false`
 
 Whether to switch from the default prefetching mode to the prerendering mode for the links inside the viewport.
 
@@ -29,43 +29,43 @@ Whether to switch from the default prefetching mode to the prerendering mode for
 
 #### options.delay
 
-Type: `Number`  
-Default: `0`
+* Type: `Number`
+* Default: `0`
 
 The _amount of time_ each link needs to stay inside the viewport before being prefetched, in milliseconds.
 
 #### options.el
 
-Type: `HTMLElement|NodeList<A>`  
-Default: `document.body`
+* Type: `HTMLElement|NodeList<A>`
+* Default: `document.body`
 
 The DOM element to observe for in-viewport links to prefetch or the NodeList of Anchor Elements.
 
 #### options.limit
 
-Type: `Number`  
-Default: `Infinity`
+* Type: `Number`
+* Default: `Infinity`
 
 The _total_ requests that can be prefetched while observing the `options.el` container.
 
 #### options.threshold
 
-Type: `Number`  
-Default: `0`
+* Type: `Number`
+* Default: `0`
 
 The _area percentage_ of each link that must have entered the viewport to be fetched, in its decimal form (e.g. 0.25 = 25%).
 
 #### options.throttle
 
-Type: `Number`  
-Default: `Infinity`
+* Type: `Number`
+* Default: `Infinity`
 
 The _concurrency limit_ for simultaneous requests while observing the `options.el` container.
 
 #### options.timeout
 
-Type: `Number`  
-Default: `2000`
+* Type: `Number`
+* Default: `2000`
 
 The `requestIdleCallback` timeout, in milliseconds.
 
@@ -73,18 +73,19 @@ The `requestIdleCallback` timeout, in milliseconds.
 
 #### options.timeoutFn
 
-Type: `Function`  
-Default: `requestIdleCallback`
+* Type: `Function`
+* Default: `requestIdleCallback`
 
-A function used for specifying a `timeout` delay.  
+A function used for specifying a `timeout` delay.
+
 This can be swapped out for a custom function like [networkIdleCallback](https://github.com/pastelsky/network-idle-callback) (see demos).
 
 By default, this uses [`requestIdleCallback`](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback) or the embedded polyfill.
 
 #### options.priority
 
-Type: `Boolean`  
-Default: `false`
+* Type: `Boolean`
+* Default: `false`
 
 Whether or not the URLs within the `options.el` container should be treated as high priority.
 
@@ -92,18 +93,19 @@ When `true`, quicklink will attempt to use the `fetch()` API if supported (rathe
 
 #### options.origins
 
-Type: `Array<String>`  
-Default: `[location.hostname]`
+* Type: `Array<String>`
+* Default: `[location.hostname]`
 
-A static array of URL hostnames that are allowed to be prefetched.  
+A static array of URL hostnames that are allowed to be prefetched.
+
 Defaults to the same domain origin, which prevents _any_ cross-origin requests.
 
 **Important:** An empty array (`[]`) allows **_all origins_** to be prefetched.
 
 #### options.ignores
 
-Type: `RegExp` or `Function` or `Array`  
-Default: `[]`
+* Type: `RegExp` or `Function` or `Array`
+* Default: `[]`
 
 Determine if a URL should be prefetched.
 
@@ -115,16 +117,17 @@ When a `RegExp` tests positive, a `Function` returns `true`, or an `Array` conta
 
 #### options.onError
 
-Type: `Function`  
-Default: None
+* Type: `Function`
+* Default: None
 
-An optional error handler that will receive any errors from prefetched requests.  
+An optional error handler that will receive any errors from prefetched requests.
+
 By default, these errors are silently ignored.
 
 #### options.hrefFn
 
-Type: `Function`  
-Default: None
+* Type: `Function`
+* Default: None
 
 An optional function to generate the URL to prefetch. It receives an [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) as the argument.
 
@@ -138,8 +141,8 @@ The `urls` provided are always passed through `Promise.all`, which means the res
 
 #### urls
 
-Type: `String` or `Array<String>`  
-Required: `true`
+* Type: `String` or `Array<String>`
+* Required: `true`
 
 One or many URLs to be prefetched.
 
@@ -147,10 +150,11 @@ One or many URLs to be prefetched.
 
 #### isPriority
 
-Type: `Boolean`  
-Default: `false`
+* Type: `Boolean`
+* Default: `false`
 
-Whether or not the URL(s) should be treated as "high priority" targets.  
+Whether or not the URL(s) should be treated as "high priority" targets.
+
 By default, calls to `prefetch()` are low priority.
 
 > **Note:** This behaves identically to `listen()`'s `priority` option.
@@ -163,8 +167,8 @@ Returns: `Promise`
 
 #### urls
 
-Type: `String` or `Array<String>`  
-Required: `true`
+* Type: `String` or `Array<String>`
+* Required: `true`
 
 One or many URLs to be prerendered.
 


### PR DESCRIPTION
There might be another way to fix this, but I'm not too familiar with eleventy, so this fixes the `<br>`s shown for now :)

Another solution would be to switch these to a list in README and api.

Let me know which solution you prefer!