### PR TITLE
site: remove unneeded type from script

### DIFF
--- a/site/src/_includes/layouts/base.njk
+++ b/site/src/_includes/layouts/base.njk
@@ -28,7 +28,7 @@
     gtag('config', 'GA_MEASUREMENT_ID', { 'transport_type': 'beacon' });
     gtag('config', 'UA-153597376-1');
   </script>
-  <script type="text/javascript" src="{{ '/script.js' | url }}" defer></script>
+  <script src="{{ '/script.js' | url }}" defer></script>
 </body>
 
 </html>


### PR DESCRIPTION
It's the default