### PR TITLE
site: move navbar logo to the HTML

### DIFF
--- a/site/src/_includes/layouts/header.njk
+++ b/site/src/_includes/layouts/header.njk
@@ -2,7 +2,7 @@
   <div class="page-header-content">
     <div class="page-header__title">
       <a href="{{ '/' }}" class="page-header__logo-link">
-        <div class="page-header__logo-image"></div>
+        <img class="page-header__logo-image" src="/assets/images/logos/quicklink.svg" alt="Quicklink" width="222" height="53">
       </a>
       <h3 class="page-header__subtitle">{{ site.subtitle }}</h3>
     </div>

--- a/site/src/assets/styles/main.css
+++ b/site/src/assets/styles/main.css
@@ -28,7 +28,7 @@ ul {
 .page-header__title {
   display: flex;
   justify-content: flex-start;
-  align-items: flex-end;
+  align-items: center;
   padding: 7px;
 }
 
@@ -44,12 +44,8 @@ ul {
 }
 
 .page-header__logo-image {
-  background-image: url("/assets/images/logos/quicklink.svg");
   width: 160px;
-  height: 60.2px;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: contain;
+  height: auto;
   margin-right: 6px;
 }
 
@@ -279,7 +275,6 @@ main.page-main .heading em {
 
   .page-header__logo-image {
     width: 200px;
-    height: 75.23px;
   }
 
   .small-github {
@@ -327,7 +322,6 @@ main.page-main .heading em {
 
   .page-header__logo-image {
     width: 222px;
-    height: 84px;
   }
 
   .page-header nav {


### PR DESCRIPTION
Preview:

<img src="https://user-images.githubusercontent.com/349621/233159194-2c3c6a45-96d4-4f30-85d6-767d1909222b.png" alt="image" width="450">

---

I didn't preload the image @addyosmani, let me know if you think we should.

* main: https://google-chrome-labs-quicklink.netlify.app/
* this PR: https://deploy-preview-360--google-chrome-labs-quicklink.netlify.app/