### PR TITLE
request-idle-callback.mjs: switch to a named export

### DIFF
--- a/src/chunks.mjs
+++ b/src/chunks.mjs
@@ -16,7 +16,7 @@
 
 import throttle from 'throttles';
 import {viaFetch, supported} from './prefetch.mjs';
-import requestIdleCallback from './request-idle-callback.mjs';
+import {requestIdleCallback} from './request-idle-callback.mjs';
 
 // Cache of URLs we've prefetched
 // Its `size` is compared against `opts.limit` value.

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -16,7 +16,7 @@
 
 import throttle from 'throttles';
 import {prefetchOnHover, supported, viaFetch} from './prefetch.mjs';
-import requestIdleCallback from './request-idle-callback.mjs';
+import {requestIdleCallback} from './request-idle-callback.mjs';
 import {addSpeculationRules, hasSpecRulesSupport} from './prerender.mjs';
 
 // Cache of URLs we've prefetched

--- a/src/request-idle-callback.mjs
+++ b/src/request-idle-callback.mjs
@@ -28,4 +28,6 @@ const requestIdleCallback = window.requestIdleCallback ||
     }, 1);
   };
 
-export default requestIdleCallback;
+export {
+  requestIdleCallback,
+};


### PR DESCRIPTION
**WARNING**: Can this be considered a breaking change? AFAICT this is not public API, but if it's considered a BC let's postpone it for v3.0.0.