### PR TITLE
site: switch to using `EleventyHtmlBasePlugin`

### DIFF
--- a/site/.eleventy.js
+++ b/site/.eleventy.js
@@ -2,10 +2,11 @@
 
 'use strict';
 
+const {EleventyHtmlBasePlugin: htmlBasePlugin} = require('@11ty/eleventy');
 const navigationPlugin = require('@11ty/eleventy-navigation');
 const syntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
-const markdownIt = require('markdown-it');
 const htmlminifier = require('html-minifier-terser');
+const markdownIt = require('markdown-it');
 
 const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 
@@ -31,6 +32,7 @@ const htmlminifierConfig = {
 };
 
 module.exports = eleventyConfig => {
+  eleventyConfig.addPlugin(htmlBasePlugin, {baseHref: '/'});
   eleventyConfig.addPlugin(navigationPlugin);
   eleventyConfig.addPlugin(syntaxHighlight);
 

--- a/site/src/_includes/layouts/base.njk
+++ b/site/src/_includes/layouts/base.njk
@@ -16,7 +16,7 @@
       quicklink.listen();
     });
   </script>
-  <link rel="stylesheet" href="{{ '/styles/prism.css' | url }}">
+  <link rel="stylesheet" href="{{ '/styles/prism.css' }}">
   <script defer src="https://buttons.github.io/buttons.js"></script>
   <script defer src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.11/clipboard.min.js" integrity="sha512-7O5pXpc0oCRrxk8RUfDYFgn0nO1t+jLuIOQdOMRp4APB7uZ4vSjspzp5y6YDtDs4VzUSTbWzBFZ/LKJhnyFOKw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <!-- Global site tag (gtag.js) - Google Analytics -->
@@ -28,7 +28,7 @@
     gtag('config', 'GA_MEASUREMENT_ID', { 'transport_type': 'beacon' });
     gtag('config', 'UA-153597376-1');
   </script>
-  <script src="{{ '/script.js' | url }}" defer></script>
+  <script defer src="{{ '/script.js' }}"></script>
 </body>
 
 </html>

--- a/site/src/_includes/layouts/head.njk
+++ b/site/src/_includes/layouts/head.njk
@@ -21,18 +21,18 @@
   <link rel="manifest" href="/site.webmanifest">
   <link rel="mask-icon" href="/assets/images/icons/safari-pinned-tab.svg" color="#5bbad5">
   <meta name="theme-color" content="#fff">
-  <link rel="preload" href="{{ '/styles/main.css' | url }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="{{ '/styles/footer.css' | url }}" as="style"
+  <link rel="preload" href="{{ '/styles/main.css' }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <link rel="preload" href="{{ '/styles/footer.css' }}" as="style"
     onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="preload" href="{{ '/styles/github-markdown.min.css' | url }}" as="style"
+  <link rel="preload" href="{{ '/styles/github-markdown.min.css' }}" as="style"
     onload="this.onload=null;this.rel='stylesheet'">
-  <link rel="stylesheet" href="{{ '/styles/main.css' | url }}">
-  <link rel="stylesheet" href="{{ '/styles/footer.css' | url }}">
-  <link rel="stylesheet" href="{{ '/styles/copy-snippet.css' | url }}">
-  <link rel="stylesheet" href="{{ '/styles/github-markdown.css' | url }}">
+  <link rel="stylesheet" href="{{ '/styles/main.css' }}">
+  <link rel="stylesheet" href="{{ '/styles/footer.css' }}">
+  <link rel="stylesheet" href="{{ '/styles/copy-snippet.css' }}">
+  <link rel="stylesheet" href="{{ '/styles/github-markdown.css' }}">
   {# TODO: opt for theme and tweak the background color by avoiding github markdown #}
   <noscript>
-    <link rel="stylesheet" href="{{ '/styles/github-markdown.min.css' | url }}">
+    <link rel="stylesheet" href="{{ '/styles/github-markdown.min.css' }}">
   </noscript>
 
   {% set cssrelpreloadJs -%}

--- a/site/src/_includes/layouts/header.njk
+++ b/site/src/_includes/layouts/header.njk
@@ -1,7 +1,7 @@
 <header class="page-header primary-font-color">
   <div class="page-header-content">
     <div class="page-header__title">
-      <a href="{{ '/' | url }}" class="page-header__logo-link">
+      <a href="{{ '/' }}" class="page-header__logo-link">
         <div class="page-header__logo-image"></div>
       </a>
       <h3 class="page-header__subtitle">{{ site.subtitle }}</h3>
@@ -11,7 +11,7 @@
       <ul>
         {%- for entry in navPages %}
           <li>
-            <a href="{{ entry.url | url }}"{% if page.url === entry.url %} class="active" aria-current="page"{% endif %}>
+            <a href="{{ entry.url }}"{% if page.url === entry.url %} class="active" aria-current="page"{% endif %}>
               <strong class="primary-font-color">{{ entry.title }}</strong>
             </a>
           </li>


### PR DESCRIPTION
This should be more safe in case the base is changed and it's less stuff to handle manually in templates.

See https://www.11ty.dev/docs/plugins/html-base/

Might need to rebase #361 after this one, or this one after #361