### PR TITLE
site: specify loading=lazy for "Use With" images

### DIFF
--- a/site/src/_includes/components/use-with.njk
+++ b/site/src/_includes/components/use-with.njk
@@ -5,7 +5,7 @@
   <div class="flex-grid overflow-x-auto">
     {% for framework in site.useWithFrameworks %}
       <a class="flex-grid__item" href="{{ framework.url }}" target="_blank" rel="noopener noreferrer">
-        <img src="/assets/images/logos/{{ framework.logoFileName }}" style="width: 112px; min-width: 92px" alt="{{ framework.title }}">
+        <img loading="lazy" src="/assets/images/logos/{{ framework.logoFileName }}" style="width: 112px; min-width: 92px" alt="{{ framework.title }}">
       </a>
     {% endfor %}
   </div>


### PR DESCRIPTION
Ideally these images should have width and height attributes too, but it should do the job for now, I guess.