### PR TITLE
Fix duplicate links not being preloaded

### DIFF
--- a/test/fixtures/test-basic-usage.html
+++ b/test/fixtures/test-basic-usage.html
@@ -16,6 +16,7 @@
     <a href="main.css">CSS</a>
   </section>
   <a href="4.html" style="position:absolute;margin-top:900px;">Link 4</a>
+  <a href="1.html" style="position:absolute;margin-top:1000px;">Link 1 again</a>
   <script src="../../dist/quicklink.umd.js"></script>
   <script>
     quicklink.listen();

--- a/test/quicklink.spec.js
+++ b/test/quicklink.spec.js
@@ -40,6 +40,7 @@ mainSuite('should prefetch in-viewport links correctly (UMD)', async context => 
   assert.ok(responseURLs.includes(`${server}/1.html`));
   assert.ok(responseURLs.includes(`${server}/2.html`));
   assert.ok(responseURLs.includes(`${server}/3.html`));
+  assert.ok(!responseURLs.includes(`${server}/4.html`));
 });
 
 mainSuite('should prefetch in-viewport links correctly (ES Modules)', async context => {
@@ -53,6 +54,7 @@ mainSuite('should prefetch in-viewport links correctly (ES Modules)', async cont
   assert.ok(responseURLs.includes(`${server}/1.html`));
   assert.ok(responseURLs.includes(`${server}/2.html`));
   assert.ok(responseURLs.includes(`${server}/3.html`));
+  assert.ok(!responseURLs.includes(`${server}/4.html`));
 });
 
 mainSuite('should prefetch in-viewport links that scroll into view correctly (UMD)', async context => {


### PR DESCRIPTION
- Index visible links by href first, by element second
- Fixes issue #387 where duplicate links with identical hrefs won't preload at all if one link is visible and another one isn't
