### PR TITLE
Update polyfill link

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,10 +286,10 @@ One or many URLs to be prerendered.
 `quicklink`:
 
 - Includes a very small fallback for [requestIdleCallback](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback)
-- Requires `IntersectionObserver` to be supported (see [Can I Use](https://caniuse.com/intersectionobserver)). We recommend conditionally polyfilling this feature with a service like Polyfill.io:
+- Requires `IntersectionObserver` to be supported (see [Can I Use](https://caniuse.com/intersectionobserver)). We recommend conditionally polyfilling this feature with a service like polyfill-fastly.io:
 
 ```html
-<script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
+<script src="https://polyfill-fastly.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 ```
 
 Alternatively, see the [Intersection Observer polyfill](https://github.com/GoogleChromeLabs/intersection-observer).

--- a/site/src/api.njk
+++ b/site/src/api.njk
@@ -190,11 +190,11 @@ One or many URLs to be prerendered.
 `quicklink`:
 
 - Includes a very small fallback for [requestIdleCallback](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback)
-- Requires `IntersectionObserver` to be supported (see [Can I Use](https://caniuse.com/intersectionobserver)). We recommend conditionally polyfilling this feature with a service like Polyfill.io:
+- Requires `IntersectionObserver` to be supported (see [Can I Use](https://caniuse.com/intersectionobserver)). We recommend conditionally polyfilling this feature with a service like polyfill-fastly.io:
 
 {% endmarkdownConvert %}
 {% highlight "html" %}
-<script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
+<script src="https://polyfill-fastly.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 {% endhighlight %}
 {% markdownConvert %}
 Alternatively, see the [Intersection Observer polyfill](https://github.com/GoogleChromeLabs/intersection-observer).

--- a/translations/zh-cn/README.md
+++ b/translations/zh-cn/README.md
@@ -99,10 +99,10 @@ quicklink();
 `quicklink`:
 
 - [requestIdleCallback](https://developer.mozilla.org/zh-CN/docs/Web/API/Window/requestIdleCallback) 的一个非常小的回退。
-- 需要支持 `IntersectionObserver` （请参阅 [CanIUse](https://caniuse.com/#feat=intersectionobserver)）。我们推荐使用 Polyfill.io 等服务选择性地实现此功能：
+- 需要支持 `IntersectionObserver` （请参阅 [CanIUse](https://caniuse.com/#feat=intersectionobserver)）。我们推荐使用 polyfill-fastly.io 等服务选择性地实现此功能：
 
 ```html
-<script src="https://polyfill.io/v2/polyfill.min.js?features=IntersectionObserver"></script>
+<script src="https://polyfill-fastly.io/v3/polyfill.min.js?features=IntersectionObserver"></script>
 ```
 
 或者，请参见 [Intersection Observer polyfill](https://github.com/GoogleChromeLabs/intersection-observer)。


### PR DESCRIPTION
The usage of polyfill.io is not secure. Please refer to the following link for details : https://sansec.io/research/polyfill-supply-chain-attack

So switch to Fastly. More information can be found here : https://community.fastly.com/t/new-options-for-polyfill-io-users/2540