### PR TITLE
CROSSORIGIN and CREDENTIALS on prefetch requests

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,22 +1,22 @@
 [
   {
     "path": "dist/quicklink.js",
-    "limit": "2.36 kB",
+    "limit": "2 kB",
     "gzip": true
   },
   {
     "path": "dist/quicklink.mjs",
-    "limit": "2.36 kB",
+    "limit": "2 kB",
     "gzip": true
   },
   {
     "path": "dist/quicklink.modern.mjs",
-    "limit": "1.91 kB",
+    "limit": "1.6 kB",
     "gzip": true
   },
   {
     "path": "dist/quicklink.umd.js",
-    "limit": "2.43 kB",
+    "limit": "2 kB",
     "gzip": true
   }
 ]

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,22 +1,22 @@
 [
   {
     "path": "dist/quicklink.js",
-    "limit": "2.35 kB",
+    "limit": "2.36 kB",
     "gzip": true
   },
   {
     "path": "dist/quicklink.mjs",
-    "limit": "2.35 kB",
+    "limit": "2.36 kB",
     "gzip": true
   },
   {
     "path": "dist/quicklink.modern.mjs",
-    "limit": "1.9 kB",
+    "limit": "1.91 kB",
     "gzip": true
   },
   {
     "path": "dist/quicklink.umd.js",
-    "limit": "2.4 kB",
+    "limit": "2.43 kB",
     "gzip": true
   }
 ]

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,22 +1,22 @@
 [
   {
     "path": "dist/quicklink.js",
-    "limit": "2 kB",
+    "limit": "2.35 kB",
     "gzip": true
   },
   {
     "path": "dist/quicklink.mjs",
-    "limit": "2 kB",
+    "limit": "2.35 kB",
     "gzip": true
   },
   {
     "path": "dist/quicklink.modern.mjs",
-    "limit": "1.6 kB",
+    "limit": "1.9 kB",
     "gzip": true
   },
   {
     "path": "dist/quicklink.umd.js",
-    "limit": "2 kB",
+    "limit": "2.4 kB",
     "gzip": true
   }
 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quicklink",
-  "version": "2.4.0",
+  "version": "2.3.0",
   "description": "Faster subsequent page-loads by prefetching in-viewport links during idle time",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quicklink",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Faster subsequent page-loads by prefetching in-viewport links during idle time",
   "repository": {
     "type": "git",

--- a/src/chunks.mjs
+++ b/src/chunks.mjs
@@ -15,7 +15,7 @@
  **/
 
 import throttle from 'throttles';
-import {priority, supported} from './prefetch.mjs';
+import { viaFetch, supported } from './prefetch.mjs';
 import requestIdleCallback from './request-idle-callback.mjs';
 
 // Cache of URLs we've prefetched
@@ -67,15 +67,15 @@ export function listen(options = {}) {
 
   const timeoutFn = options.timeoutFn || requestIdleCallback;
 
-  const {prefetchChunks} = options;
+  const { prefetchChunks } = options;
 
   const prefetchHandler = urls => {
     prefetch(urls, options.priority)
-        .then(isDone)
-        .catch(error => {
-          isDone();
-          if (options.onError) options.onError(error);
-        });
+      .then(isDone)
+      .catch(error => {
+        isDone();
+        if (options.onError) options.onError(error);
+      });
   };
 
   const observer = new IntersectionObserver(entries => {
@@ -123,7 +123,7 @@ export function listen(options = {}) {
  * @return {Object} a Promise
  */
 export function prefetch(url, isPriority) {
-  const {connection} = navigator;
+  const { connection } = navigator;
 
   if (connection) {
     // Don't prefetch if using 2G or if Save-Data is enabled.
@@ -138,16 +138,16 @@ export function prefetch(url, isPriority) {
 
   // Dev must supply own catch()
   return Promise.all(
-      [].concat(url).map(str => {
-        if (toPrefetch.has(str)) return [];
+    [].concat(url).map(str => {
+      if (toPrefetch.has(str)) return [];
 
-        // Add it now, regardless of its success
-        // ~> so that we don't repeat broken links
-        toPrefetch.add(str);
+      // Add it now, regardless of its success
+      // ~> so that we don't repeat broken links
+      toPrefetch.add(str);
 
-        return (isPriority ? priority : supported)(
-            new URL(str, location.href).toString(),
-        );
-      }),
+      return (isPriority ? viaFetch : supported)(
+        new URL(str, location.href).toString(),
+      );
+    }),
   );
 }

--- a/src/chunks.mjs
+++ b/src/chunks.mjs
@@ -15,7 +15,7 @@
  **/
 
 import throttle from 'throttles';
-import { viaFetch, supported } from './prefetch.mjs';
+import {viaFetch, supported} from './prefetch.mjs';
 import requestIdleCallback from './request-idle-callback.mjs';
 
 // Cache of URLs we've prefetched
@@ -67,15 +67,15 @@ export function listen(options = {}) {
 
   const timeoutFn = options.timeoutFn || requestIdleCallback;
 
-  const { prefetchChunks } = options;
+  const {prefetchChunks} = options;
 
   const prefetchHandler = urls => {
     prefetch(urls, options.priority)
-      .then(isDone)
-      .catch(error => {
-        isDone();
-        if (options.onError) options.onError(error);
-      });
+        .then(isDone)
+        .catch(error => {
+          isDone();
+          if (options.onError) options.onError(error);
+        });
   };
 
   const observer = new IntersectionObserver(entries => {
@@ -123,7 +123,7 @@ export function listen(options = {}) {
  * @return {Object} a Promise
  */
 export function prefetch(url, isPriority) {
-  const { connection } = navigator;
+  const {connection} = navigator;
 
   if (connection) {
     // Don't prefetch if using 2G or if Save-Data is enabled.
@@ -138,16 +138,16 @@ export function prefetch(url, isPriority) {
 
   // Dev must supply own catch()
   return Promise.all(
-    [].concat(url).map(str => {
-      if (toPrefetch.has(str)) return [];
+      [].concat(url).map(str => {
+        if (toPrefetch.has(str)) return [];
 
-      // Add it now, regardless of its success
-      // ~> so that we don't repeat broken links
-      toPrefetch.add(str);
+        // Add it now, regardless of its success
+        // ~> so that we don't repeat broken links
+        toPrefetch.add(str);
 
-      return (isPriority ? viaFetch : supported)(
-        new URL(str, location.href).toString(),
-      );
-    }),
+        return (isPriority ? viaFetch : supported)(
+            new URL(str, location.href).toString(),
+        );
+      }),
   );
 }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -73,6 +73,7 @@ function checkConnection(conn) {
  * @param {Object|Array} [options.el] - DOM element(s) to prefetch in-viewport links of
  * @param {Boolean} [options.priority] - Attempt higher priority fetch (low or high)
  * @param {Boolean} [options.checkAccessControlAllowOrigin] - Check if the Access-Control-Allow-Origin response header is correctly setted
+ * @param {Boolean} [options.checkAccessControlAllowCredentials] - Check if the Access-Control-Allow-Credentials response header is correctly setted
  * @param {Array} [options.origins] - Allowed origins to prefetch (empty allows all)
  * @param {Array|RegExp|Function} [options.ignores] - Custom filter(s) that run after origin checks
  * @param {Number} [options.timeout] - Timeout after which prefetching will occur
@@ -148,7 +149,7 @@ export function listen(options = {}) {
           // Do not prefetch if will match/exceed limit and user has not switched to shouldOnlyPrerender mode
           if (toPrefetch.size < limit && !shouldOnlyPrerender) {
             toAdd(() => {
-              prefetch(hrefFn ? hrefFn(entry) : entry.href, options.priority, options.checkAccessControlAllowOrigin)
+              prefetch(hrefFn ? hrefFn(entry) : entry.href, options.priority, options.checkAccessControlAllowOrigin, options.checkAccessControlAllowCredentials)
                 .then(isDone)
                 .catch(error => {
                   isDone();
@@ -205,9 +206,10 @@ export function listen(options = {}) {
 * @param {Boolean} isPriority - if is "high" priority
 * @param {Boolean} checkAccessControlAllowOrigin - true to set crossorigin="anonymous" for DOM prefetch 
 *                                                    and mode:'cors' for API fetch
+* @param {Boolean} checkAccessControlAllowCredentials - true to set credentials:'include' for API fetch
 * @return {Object} a Promise
 */
-export function prefetch(url, isPriority, checkAccessControlAllowOrigin) {
+export function prefetch(url, isPriority, checkAccessControlAllowOrigin, checkAccessControlAllowCredentials) {
   const chkConn = checkConnection(navigator.connection);
   if (chkConn instanceof Error) {
     return Promise.reject(new Error(`Cannot prefetch, ${chkConn.message}`));
@@ -227,7 +229,7 @@ export function prefetch(url, isPriority, checkAccessControlAllowOrigin) {
       toPrefetch.add(str);
 
       return (isPriority ? viaFetch : supported)(
-        new URL(str, location.href).toString(), checkAccessControlAllowOrigin, isPriority
+        new URL(str, location.href).toString(), checkAccessControlAllowOrigin, checkAccessControlAllowCredentials, isPriority
       );
     }),
   );

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -15,7 +15,7 @@
  **/
 
 import throttle from 'throttles';
-import { priority, supported } from './prefetch.mjs';
+import { supported, viaFetch } from './prefetch.mjs';
 import requestIdleCallback from './request-idle-callback.mjs';
 import { addSpeculationRules, hasSpecRulesSupport } from './prerender.mjs';
 
@@ -72,6 +72,7 @@ function checkConnection(conn) {
  * @param {Object} options - Configuration options for quicklink
  * @param {Object|Array} [options.el] - DOM element(s) to prefetch in-viewport links of
  * @param {Boolean} [options.priority] - Attempt higher priority fetch (low or high)
+ * @param {Boolean} [options.checkAccessControlAllowOrigin] - Check if the Access-Control-Allow-Origin response header is correctly setted
  * @param {Array} [options.origins] - Allowed origins to prefetch (empty allows all)
  * @param {Array|RegExp|Function} [options.ignores] - Custom filter(s) that run after origin checks
  * @param {Number} [options.timeout] - Timeout after which prefetching will occur
@@ -147,7 +148,7 @@ export function listen(options = {}) {
           // Do not prefetch if will match/exceed limit and user has not switched to shouldOnlyPrerender mode
           if (toPrefetch.size < limit && !shouldOnlyPrerender) {
             toAdd(() => {
-              prefetch(hrefFn ? hrefFn(entry) : entry.href, options.priority)
+              prefetch(hrefFn ? hrefFn(entry) : entry.href, options.priority, options.checkAccessControlAllowOrigin)
                 .then(isDone)
                 .catch(error => {
                   isDone();
@@ -225,8 +226,8 @@ export function prefetch(url, isPriority, checkAccessControlAllowOrigin) {
       // ~> so that we don't repeat broken links
       toPrefetch.add(str);
 
-      return (isPriority ? priority : supported)(
-        new URL(str, location.href).toString(), checkAccessControlAllowOrigin
+      return (isPriority ? viaFetch : supported)(
+        new URL(str, location.href).toString(), checkAccessControlAllowOrigin, isPriority
       );
     }),
   );

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -202,8 +202,8 @@ export function listen(options = {}) {
 /**
 * Prefetch a given URL with an optional preferred fetch priority
 * @param {String} url - the URL to fetch
-* @param {Boolean} [isPriority] - if is "high" priority
-* @param {Boolean} [checkAccessControlAllowOrigin] - true to set crossorigin="anonymous" for DOM prefetch 
+* @param {Boolean} isPriority - if is "high" priority
+* @param {Boolean} checkAccessControlAllowOrigin - true to set crossorigin="anonymous" for DOM prefetch 
 *                                                    and mode:'cors' for API fetch
 * @return {Object} a Promise
 */

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -253,7 +253,27 @@ export function prerender(urls, eagerness) {
   // 1) whether UA supports spec rules.. If not, fallback to prefetch
   // Note: Prerendering supports same-site cross origin with opt-in header
   if (!hasSpecRulesSupport()) {
-    prefetch(urls);
+    if (eagerness === 'moderate' || eagerness === 'conservative') {
+      console.log('URLS', Array(urls));
+      const elements = document.querySelectorAll(Array(urls).map(url => `a[href="${decodeURIComponent(url)}"]`).join(','));
+      console.log('elements', elements);
+      for (const el of elements) {
+        console.log('el', el);
+        let timer = null;
+        el.addEventListener('mouseenter', e => {
+          timer = setTimeout(() => {
+            console.log('prefetch', e.target.href);
+            prefetch(e.target.href);
+          }, 200);
+        });
+        el.addEventListener('mouseleave', e => {
+          clearTimeout(timer);
+          timer = null;
+        });
+      }
+    } else {
+      prefetch(urls);
+    }
     return Promise.reject(new Error('This browser does not support the speculation rules API. Falling back to prefetch.'));
   }
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -15,9 +15,9 @@
  **/
 
 import throttle from 'throttles';
-import {supported, viaFetch} from './prefetch.mjs';
+import { supported, viaFetch } from './prefetch.mjs';
 import requestIdleCallback from './request-idle-callback.mjs';
-import {addSpeculationRules, hasSpecRulesSupport} from './prerender.mjs';
+import { addSpeculationRules, hasSpecRulesSupport } from './prerender.mjs';
 
 // Cache of URLs we've prefetched
 // Its `size` is compared against `opts.limit` value.
@@ -74,7 +74,6 @@ function checkConnection(conn) {
  * @param {Boolean} [options.priority] - Attempt higher priority fetch (low or high)
  * @param {Boolean} [options.checkAccessControlAllowOrigin] - Check Access-Control-Allow-Origin response header
  * @param {Boolean} [options.checkAccessControlAllowCredentials] - Check the Access-Control-Allow-Credentials response header
- * @param {Boolean} [options.onlyOnMouseover] - Enable the prefetch only on mouseover event
  * @param {Array} [options.origins] - Allowed origins to prefetch (empty allows all)
  * @param {Array|RegExp|Function} [options.ignores] - Custom filter(s) that run after origin checks
  * @param {Number} [options.timeout] - Timeout after which prefetching will occur
@@ -151,12 +150,12 @@ export function listen(options = {}) {
           if (toPrefetch.size < limit && !shouldOnlyPrerender) {
             toAdd(() => {
               prefetch(hrefFn ? hrefFn(entry) : entry.href, options.priority,
-                  options.checkAccessControlAllowOrigin, options.checkAccessControlAllowCredentials)
-                  .then(isDone)
-                  .catch(error => {
-                    isDone();
-                    if (options.onError) options.onError(error);
-                  });
+                options.checkAccessControlAllowOrigin, options.checkAccessControlAllowCredentials)
+                .then(isDone)
+                .catch(error => {
+                  isDone();
+                  if (options.onError) options.onError(error);
+                });
             });
           }
         }, delay);
@@ -223,16 +222,16 @@ export function prefetch(url, isPriority, checkAccessControlAllowOrigin, checkAc
 
   // Dev must supply own catch()
   return Promise.all(
-      [].concat(url).map(str => {
-        if (toPrefetch.has(str)) return [];
+    [].concat(url).map(str => {
+      if (toPrefetch.has(str)) return [];
 
-        // Add it now, regardless of its success
-        // ~> so that we don't repeat broken links
-        toPrefetch.add(str);
+      // Add it now, regardless of its success
+      // ~> so that we don't repeat broken links
+      toPrefetch.add(str);
 
-        return (isPriority ? viaFetch : supported)(new URL(str, location.href).toString(),
-            checkAccessControlAllowOrigin, checkAccessControlAllowCredentials, isPriority);
-      }),
+      return (isPriority ? viaFetch : supported)(new URL(str, location.href).toString(),
+        checkAccessControlAllowOrigin, checkAccessControlAllowCredentials, isPriority);
+    }),
   );
 }
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -202,6 +202,7 @@ export function listen(options = {}) {
 * Prefetch a given URL with an optional preferred fetch priority
 * @param {String} url - the URL to fetch
 * @param {Boolean} [isPriority] - if is "high" priority
+* @param {Boolean} [isCrossorigin] - true to set crossorigin="anonymous"
 * @return {Object} a Promise
 */
 export function prefetch(url, isPriority, isCrossorigin) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -86,6 +86,7 @@ function checkConnection(conn) {
  * @param {Function} [options.hrefFn] - Function to use to build the URL to prefetch.
  *                                             If it's not a valid function, then it will use the entry href.
  * @param {Boolean} [options.prerender] - Option to switch from prefetching and use prerendering only
+ * @param {String} [options.eagerness] - Prerender eagerness mode - default immediate
  * @param {Boolean} [options.prerenderAndPrefetch] - Option to use both prerendering and prefetching
  * @return {Function}
  */
@@ -135,7 +136,7 @@ export function listen(options = {}) {
           // either it's the prerender + prefetch mode or it's prerender *only* mode
           // Prerendering limit is following options.limit. UA may impose arbitraty numeric limit
           if ((shouldPrerenderAndPrefetch || shouldOnlyPrerender) && toPrerender.size < limit) {
-            prerender(hrefFn ? hrefFn(entry) : entry.href).catch(error => {
+            prerender(hrefFn ? hrefFn(entry) : entry.href, options.eagerness).catch(error => {
               if (options.onError) {
                 options.onError(error);
               } else {
@@ -239,9 +240,10 @@ export function prefetch(url, isPriority, checkAccessControlAllowOrigin, checkAc
 /**
 * Prerender a given URL
 * @param {String} urls - the URL to fetch
+* @param {String} eagerness - prerender eagerness mode - default immediate
 * @return {Object} a Promise
 */
-export function prerender(urls) {
+export function prerender(urls, eagerness) {
   const chkConn = checkConnection(navigator.connection);
   if (chkConn instanceof Error) {
     return Promise.reject(new Error(`Cannot prerender, ${chkConn.message}`));
@@ -264,6 +266,6 @@ export function prerender(urls) {
     console.warn('[Warning] You are using both prefetching and prerendering on the same document');
   }
 
-  const addSpecRules = addSpeculationRules(toPrerender);
+  const addSpecRules = addSpeculationRules(toPrerender, eagerness);
   return addSpecRules === true ? Promise.resolve() : Promise.reject(addSpecRules);
 }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -15,9 +15,9 @@
  **/
 
 import throttle from 'throttles';
-import { supported, viaFetch } from './prefetch.mjs';
+import {supported, viaFetch} from './prefetch.mjs';
 import requestIdleCallback from './request-idle-callback.mjs';
-import { addSpeculationRules, hasSpecRulesSupport } from './prerender.mjs';
+import {addSpeculationRules, hasSpecRulesSupport} from './prerender.mjs';
 
 // Cache of URLs we've prefetched
 // Its `size` is compared against `opts.limit` value.
@@ -72,8 +72,8 @@ function checkConnection(conn) {
  * @param {Object} options - Configuration options for quicklink
  * @param {Object|Array} [options.el] - DOM element(s) to prefetch in-viewport links of
  * @param {Boolean} [options.priority] - Attempt higher priority fetch (low or high)
- * @param {Boolean} [options.checkAccessControlAllowOrigin] - Check if the Access-Control-Allow-Origin response header is correctly setted
- * @param {Boolean} [options.checkAccessControlAllowCredentials] - Check if the Access-Control-Allow-Credentials response header is correctly setted
+ * @param {Boolean} [options.checkAccessControlAllowOrigin] - Check Access-Control-Allow-Origin response header
+ * @param {Boolean} [options.checkAccessControlAllowCredentials] - Check the Access-Control-Allow-Credentials response header
  * @param {Array} [options.origins] - Allowed origins to prefetch (empty allows all)
  * @param {Array|RegExp|Function} [options.ignores] - Custom filter(s) that run after origin checks
  * @param {Number} [options.timeout] - Timeout after which prefetching will occur
@@ -149,12 +149,13 @@ export function listen(options = {}) {
           // Do not prefetch if will match/exceed limit and user has not switched to shouldOnlyPrerender mode
           if (toPrefetch.size < limit && !shouldOnlyPrerender) {
             toAdd(() => {
-              prefetch(hrefFn ? hrefFn(entry) : entry.href, options.priority, options.checkAccessControlAllowOrigin, options.checkAccessControlAllowCredentials)
-                .then(isDone)
-                .catch(error => {
-                  isDone();
-                  if (options.onError) options.onError(error);
-                });
+              prefetch(hrefFn ? hrefFn(entry) : entry.href, options.priority,
+                  options.checkAccessControlAllowOrigin, options.checkAccessControlAllowCredentials)
+                  .then(isDone)
+                  .catch(error => {
+                    isDone();
+                    if (options.onError) options.onError(error);
+                  });
             });
           }
         }, delay);
@@ -204,7 +205,7 @@ export function listen(options = {}) {
 * Prefetch a given URL with an optional preferred fetch priority
 * @param {String} url - the URL to fetch
 * @param {Boolean} isPriority - if is "high" priority
-* @param {Boolean} checkAccessControlAllowOrigin - true to set crossorigin="anonymous" for DOM prefetch 
+* @param {Boolean} checkAccessControlAllowOrigin - true to set crossorigin="anonymous" for DOM prefetch
 *                                                    and mode:'cors' for API fetch
 * @param {Boolean} checkAccessControlAllowCredentials - true to set credentials:'include' for API fetch
 * @return {Object} a Promise
@@ -221,17 +222,17 @@ export function prefetch(url, isPriority, checkAccessControlAllowOrigin, checkAc
 
   // Dev must supply own catch()
   return Promise.all(
-    [].concat(url).map(str => {
-      if (toPrefetch.has(str)) return [];
+      [].concat(url).map(str => {
+        if (toPrefetch.has(str)) return [];
 
-      // Add it now, regardless of its success
-      // ~> so that we don't repeat broken links
-      toPrefetch.add(str);
+        // Add it now, regardless of its success
+        // ~> so that we don't repeat broken links
+        toPrefetch.add(str);
 
-      return (isPriority ? viaFetch : supported)(
-        new URL(str, location.href).toString(), checkAccessControlAllowOrigin, checkAccessControlAllowCredentials, isPriority
-      );
-    }),
+        return (isPriority ? viaFetch : supported)(
+            new URL(str, location.href).toString(), checkAccessControlAllowOrigin, checkAccessControlAllowCredentials, isPriority,
+        );
+      }),
   );
 }
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -15,9 +15,9 @@
  **/
 
 import throttle from 'throttles';
-import { supported, viaFetch } from './prefetch.mjs';
+import {supported, viaFetch} from './prefetch.mjs';
 import requestIdleCallback from './request-idle-callback.mjs';
-import { addSpeculationRules, hasSpecRulesSupport } from './prerender.mjs';
+import {addSpeculationRules, hasSpecRulesSupport} from './prerender.mjs';
 
 // Cache of URLs we've prefetched
 // Its `size` is compared against `opts.limit` value.
@@ -150,12 +150,12 @@ export function listen(options = {}) {
           if (toPrefetch.size < limit && !shouldOnlyPrerender) {
             toAdd(() => {
               prefetch(hrefFn ? hrefFn(entry) : entry.href, options.priority,
-                options.checkAccessControlAllowOrigin, options.checkAccessControlAllowCredentials)
-                .then(isDone)
-                .catch(error => {
-                  isDone();
-                  if (options.onError) options.onError(error);
-                });
+                  options.checkAccessControlAllowOrigin, options.checkAccessControlAllowCredentials)
+                  .then(isDone)
+                  .catch(error => {
+                    isDone();
+                    if (options.onError) options.onError(error);
+                  });
             });
           }
         }, delay);
@@ -203,14 +203,14 @@ export function listen(options = {}) {
 
 /**
 * Prefetch a given URL with an optional preferred fetch priority
-* @param {String} url - the URL to fetch
+* @param {String | String[]} urls - the URLs to fetch
 * @param {Boolean} isPriority - if is "high" priority
 * @param {Boolean} checkAccessControlAllowOrigin - true to set crossorigin="anonymous" for DOM prefetch
 *                                                    and mode:'cors' for API fetch
 * @param {Boolean} checkAccessControlAllowCredentials - true to set credentials:'include' for API fetch
 * @return {Object} a Promise
 */
-export function prefetch(url, isPriority, checkAccessControlAllowOrigin, checkAccessControlAllowCredentials) {
+export function prefetch(urls, isPriority, checkAccessControlAllowOrigin, checkAccessControlAllowCredentials) {
   const chkConn = checkConnection(navigator.connection);
   if (chkConn instanceof Error) {
     return Promise.reject(new Error(`Cannot prefetch, ${chkConn.message}`));
@@ -222,22 +222,22 @@ export function prefetch(url, isPriority, checkAccessControlAllowOrigin, checkAc
 
   // Dev must supply own catch()
   return Promise.all(
-    [].concat(url).map(str => {
-      if (toPrefetch.has(str)) return [];
+      [].concat(urls).map(str => {
+        if (toPrefetch.has(str)) return [];
 
-      // Add it now, regardless of its success
-      // ~> so that we don't repeat broken links
-      toPrefetch.add(str);
+        // Add it now, regardless of its success
+        // ~> so that we don't repeat broken links
+        toPrefetch.add(str);
 
-      return (isPriority ? viaFetch : supported)(new URL(str, location.href).toString(),
-        checkAccessControlAllowOrigin, checkAccessControlAllowCredentials, isPriority);
-    }),
+        return (isPriority ? viaFetch : supported)(new URL(str, location.href).toString(),
+            checkAccessControlAllowOrigin, checkAccessControlAllowCredentials, isPriority);
+      }),
   );
 }
 
 /**
 * Prerender a given URL
-* @param {String} urls - the URL to fetch
+* @param {String | String[]} urls - the URLs to fetch
 * @return {Object} a Promise
 */
 export function prerender(urls) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -15,7 +15,7 @@
  **/
 
 import throttle from 'throttles';
-import {addMouseoverListener, supported, viaFetch} from './prefetch.mjs';
+import {prefetchOnHover, supported, viaFetch} from './prefetch.mjs';
 import requestIdleCallback from './request-idle-callback.mjs';
 import {addSpeculationRules, hasSpecRulesSupport} from './prerender.mjs';
 
@@ -232,10 +232,8 @@ export function prefetch(url, isPriority, checkAccessControlAllowOrigin, checkAc
         // ~> so that we don't repeat broken links
         toPrefetch.add(str);
 
-        const urlToPrefetch = new URL(str, location.href).toString();
-        return addMouseoverListener(() => (isPriority ? viaFetch : supported)(
-            urlToPrefetch, checkAccessControlAllowOrigin, checkAccessControlAllowCredentials, isPriority,
-        ), urlToPrefetch, onlyOnMouseover);
+        return prefetchOnHover((isPriority ? viaFetch : supported), new URL(str, location.href).toString(), onlyOnMouseover,
+            checkAccessControlAllowOrigin, checkAccessControlAllowCredentials, isPriority);
       }),
   );
 }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -202,10 +202,11 @@ export function listen(options = {}) {
 * Prefetch a given URL with an optional preferred fetch priority
 * @param {String} url - the URL to fetch
 * @param {Boolean} [isPriority] - if is "high" priority
-* @param {Boolean} [isCrossorigin] - true to set crossorigin="anonymous"
+* @param {Boolean} [checkAccessControlAllowOrigin] - true to set crossorigin="anonymous" for DOM prefetch 
+*                                                    and mode:'cors' for API fetch
 * @return {Object} a Promise
 */
-export function prefetch(url, isPriority, isCrossorigin) {
+export function prefetch(url, isPriority, checkAccessControlAllowOrigin) {
   const chkConn = checkConnection(navigator.connection);
   if (chkConn instanceof Error) {
     return Promise.reject(new Error(`Cannot prefetch, ${chkConn.message}`));
@@ -214,8 +215,6 @@ export function prefetch(url, isPriority, isCrossorigin) {
   if (toPrerender.size > 0 && !shouldPrerenderAndPrefetch) {
     console.warn('[Warning] You are using both prefetching and prerendering on the same document');
   }
-
-  const crossorigin = isCrossorigin ? "anonymous" : "use-credentials";
 
   // Dev must supply own catch()
   return Promise.all(
@@ -227,7 +226,7 @@ export function prefetch(url, isPriority, isCrossorigin) {
       toPrefetch.add(str);
 
       return (isPriority ? priority : supported)(
-        new URL(str, location.href).toString(), crossorigin
+        new URL(str, location.href).toString(), checkAccessControlAllowOrigin
       );
     }),
   );

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -20,7 +20,7 @@
 /**
  * Checks if a feature on `link` is natively supported.
  * Examples of features include `prefetch` and `preload`.
- * @param {Object} link Link object.
+ * @param {Object} link - Link object.
  * @return {Boolean} whether the feature is supported
  */
 function hasPrefetch(link) {
@@ -40,7 +40,7 @@ function viaDOM(url, hasCrossorigin) {
     link.rel = 'prefetch';
     link.href = url;
     if (hasCrossorigin)
-      link.setAttribute("crossorigin", "anonymous");
+      link.setAttribute('crossorigin', 'anonymous');
 
     link.onload = resolve;
     link.onerror = reject;
@@ -50,37 +50,14 @@ function viaDOM(url, hasCrossorigin) {
 }
 
 /**
- * Fetches a given URL using XMLHttpRequest
- * @param {string} url - the URL to fetch
- * @return {Object} a Promise
- */
-function viaXHR(url) {
-  return new Promise((resolve, reject, request) => {
-    request = new XMLHttpRequest();
-
-    request.open('GET', url, request.withCredentials = true);
-
-    request.onload = () => {
-      if (request.status === 200) {
-        resolve();
-      } else {
-        // eslint-disable-next-line prefer-promise-reject-errors
-        reject();
-      }
-    };
-
-    request.send();
-  });
-}
-
-/**
  * Fetches a given URL using the Fetch API. Falls back
  * to XMLHttpRequest if the API is not supported.
  * @param {string} url - the URL to fetch
- * @param {Boolean} [hasModeCors] - true to set mode:'cors'
+ * @param {Boolean} hasModeCors - true to set mode:'cors'
+ * @param {Boolean} isPriority - true to set priority:'high'
  * @return {Object} a Promise
  */
-export function priority(url, hasModeCors) {
+export function viaFetch(url, hasModeCors, isPriority) {
   // TODO: Investigate using preload for high-priority
   // fetches. May have to sniff file-extension to provide
   // valid 'as' values. In the future, we may be able to
@@ -90,10 +67,9 @@ export function priority(url, hasModeCors) {
   // and medium-priority in Safari.
   options = {};
   // options.credentials = 'include';
-  if (!hasModeCors) {
-    options.mode = 'no-cors';
-  }
-  return window.fetch ? fetch(url, options) : viaXHR(url);
+  if (!hasModeCors) options.mode = 'no-cors';
+  isPriority ? options.priority = 'high' : options.priority = 'low';
+  return fetch(url, options);
 }
 
-export const supported = hasPrefetch() ? viaDOM : viaXHR;
+export const supported = hasPrefetch() ? viaDOM : viaFetch;

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -31,15 +31,16 @@ function hasPrefetch(link) {
 /**
  * Fetches a given URL using `<link rel=prefetch>`
  * @param {string} url - the URL to fetch
- * @param {string} url - the value of crossorigin attribute
+ * @param {Boolean} [hasCrossorigin] - true to set crossorigin="anonymous"
  * @return {Object} a Promise
  */
-function viaDOM(url, crossorigin) {
+function viaDOM(url, hasCrossorigin) {
   return new Promise((resolve, reject, link) => {
     link = document.createElement('link');
     link.rel = 'prefetch';
     link.href = url;
-    link.setAttribute("crossorigin", crossorigin);
+    if (hasCrossorigin)
+      link.setAttribute("crossorigin", "anonymous");
 
     link.onload = resolve;
     link.onerror = reject;
@@ -76,10 +77,10 @@ function viaXHR(url) {
  * Fetches a given URL using the Fetch API. Falls back
  * to XMLHttpRequest if the API is not supported.
  * @param {string} url - the URL to fetch
- * @param {string} url - the value of crossorigin attribute
+ * @param {Boolean} [hasModeCors] - true to set mode:'cors'
  * @return {Object} a Promise
  */
-export function priority(url, crossorigin) {
+export function priority(url, hasModeCors) {
   // TODO: Investigate using preload for high-priority
   // fetches. May have to sniff file-extension to provide
   // valid 'as' values. In the future, we may be able to
@@ -87,8 +88,11 @@ export function priority(url, crossorigin) {
   //
   // As of 2018, fetch() is high-priority in Chrome
   // and medium-priority in Safari.
-  const options = {};
-  if (crossorigin === 'use-credentials') options.credentials = 'include';
+  options = {};
+  // options.credentials = 'include';
+  if (!hasModeCors) {
+    options.mode = 'no-cors';
+  }
   return window.fetch ? fetch(url, options) : viaXHR(url);
 }
 

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -33,11 +33,12 @@ function hasPrefetch(link) {
  * @param {string} url - the URL to fetch
  * @return {Object} a Promise
  */
-function viaDOM(url) {
+function viaDOM(url, crossorigin) {
   return new Promise((resolve, reject, link) => {
     link = document.createElement('link');
     link.rel = 'prefetch';
     link.href = url;
+    link.setAttribute("crossorigin", crossorigin);
 
     link.onload = resolve;
     link.onerror = reject;
@@ -76,7 +77,7 @@ function viaXHR(url) {
  * @param {string} url - the URL to fetch
  * @return {Object} a Promise
  */
-export function priority(url) {
+export function priority(url, crossorigin) {
   // TODO: Investigate using preload for high-priority
   // fetches. May have to sniff file-extension to provide
   // valid 'as' values. In the future, we may be able to
@@ -84,7 +85,9 @@ export function priority(url) {
   //
   // As of 2018, fetch() is high-priority in Chrome
   // and medium-priority in Safari.
-  return window.fetch ? fetch(url, {credentials: 'include'}) : viaXHR(url);
+  const options = {};
+  if (crossorigin === 'use-credentials') options.credentials = 'include';
+  return window.fetch ? fetch(url, options) : viaXHR(url);
 }
 
 export const supported = hasPrefetch() ? viaDOM : viaXHR;

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -96,11 +96,7 @@ export function viaFetch(url, hasModeCors, hasCredentials, isPriority) {
   if (!hasModeCors) options.mode = 'no-cors';
   if (hasCredentials) options.credentials = 'include';
   isPriority ? options.priority = 'high' : options.priority = 'low';
-  try {
-    return fetch(url, options);
-  } catch (e) {
-    return viaXHR(url, hasCredentials);
-  }
+  return window.fetch ? fetch(url, options) : viaXHR(url, hasCredentials);
 }
 
 export const supported = hasPrefetch() ? viaDOM : viaFetch;

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -31,7 +31,7 @@ function hasPrefetch(link) {
 /**
  * Fetches a given URL using `<link rel=prefetch>`
  * @param {string} url - the URL to fetch
- * @param {Boolean} [hasCrossorigin] - true to set crossorigin="anonymous"
+ * @param {Boolean} hasCrossorigin - true to set crossorigin="anonymous"
  * @return {Object} a Promise
  */
 function viaDOM(url, hasCrossorigin) {

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -31,6 +31,7 @@ function hasPrefetch(link) {
 /**
  * Fetches a given URL using `<link rel=prefetch>`
  * @param {string} url - the URL to fetch
+ * @param {string} url - the value of crossorigin attribute
  * @return {Object} a Promise
  */
 function viaDOM(url, crossorigin) {
@@ -75,6 +76,7 @@ function viaXHR(url) {
  * Fetches a given URL using the Fetch API. Falls back
  * to XMLHttpRequest if the API is not supported.
  * @param {string} url - the URL to fetch
+ * @param {string} url - the value of crossorigin attribute
  * @return {Object} a Promise
  */
 export function priority(url, crossorigin) {

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -39,8 +39,9 @@ function viaDOM(url, hasCrossorigin) {
     link = document.createElement('link');
     link.rel = 'prefetch';
     link.href = url;
-    if (hasCrossorigin)
+    if (hasCrossorigin) {
       link.setAttribute('crossorigin', 'anonymous');
+    }
 
     link.onload = resolve;
     link.onerror = reject;

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -101,41 +101,4 @@ export function viaFetch(url, hasModeCors, hasCredentials, isPriority) {
   return window.fetch ? fetch(url, options) : viaXHR(url, hasCredentials);
 }
 
-/**
- * Calls the prefetch function immediately
- * or only on the mouseover event.
- * @param {Function} callback  - original prefetch function
- * @param {String} url - url to prefetch
- * @param {Boolean} onlyOnMouseover - true to add the mouseover listener
- * @return {Object} a Promise
- */
-export function prefetchOnHover(callback, url, onlyOnMouseover, ...args) {
-  if (!onlyOnMouseover) return callback(url, ...args);
-
-  const elements = document.querySelectorAll(`a[href="${decodeURIComponent(url)}"]`);
-  const timerMap = new Map();
-
-  for (const el of elements) {
-    const mouseenterListener = e => {
-      const timer = setTimeout(() => {
-        el.removeEventListener('mouseenter', mouseenterListener);
-        el.removeEventListener('mouseleave', mouseleaveListener);
-        return callback(url, ...args);
-      }, 200);
-      timerMap.set(el, timer);
-    };
-
-    const mouseleaveListener = e => {
-      const timer = timerMap.get(el);
-      if (timer) {
-        clearTimeout(timer);
-        timerMap.delete(el);
-      }
-    };
-
-    el.addEventListener('mouseenter', mouseenterListener);
-    el.addEventListener('mouseleave', mouseleaveListener);
-  }
-}
-
 export const supported = hasPrefetch() ? viaDOM : viaFetch;

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -62,6 +62,8 @@ function viaXHR(url, hasCredentials) {
 
     request.open('GET', url, request.withCredentials = hasCredentials);
 
+    request.setRequestHeader('Accept', '*/*');
+
     request.onload = () => {
       if (request.status === 200) {
         resolve();
@@ -92,7 +94,7 @@ export function viaFetch(url, hasModeCors, hasCredentials, isPriority) {
   //
   // As of 2018, fetch() is high-priority in Chrome
   // and medium-priority in Safari.
-  options = {};
+  options = {headers: {accept: '*/*'}};
   if (!hasModeCors) options.mode = 'no-cors';
   if (hasCredentials) options.credentials = 'include';
   isPriority ? options.priority = 'high' : options.priority = 'low';

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -111,7 +111,7 @@ export function viaFetch(url, hasModeCors, hasCredentials, isPriority) {
  */
 export function addMouseoverListener(callback, url, onlyOnMouseover) {
   if (onlyOnMouseover) {
-    const elements = document.querySelectorAll(`a[href="${url}"]`);
+    const elements = document.querySelectorAll(`a[href="${decodeURIComponent(url)}"]`);
 
     for (const el of elements) {
       const timerMap = new Map();

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -109,35 +109,32 @@ export function viaFetch(url, hasModeCors, hasCredentials, isPriority) {
  * @param {Boolean} onlyOnMouseover - true to add the mouseover listener
  * @return {Object} a Promise
  */
-export function addMouseoverListener(callback, url, onlyOnMouseover) {
-  if (onlyOnMouseover) {
-    const elements = document.querySelectorAll(`a[href="${decodeURIComponent(url)}"]`);
+export function prefetchOnHover(callback, url, onlyOnMouseover, ...args) {
+  if (!onlyOnMouseover) return callback(url, ...args);
 
-    for (const el of elements) {
-      const timerMap = new Map();
+  const elements = document.querySelectorAll(`a[href="${decodeURIComponent(url)}"]`);
+  const timerMap = new Map();
 
-      const mouseenterListener = e => {
-        const timer = setTimeout(() => {
-          el.removeEventListener('mouseenter', mouseenterListener);
-          el.removeEventListener('mouseleave', mouseleaveListener);
-          return callback();
-        }, 200);
-        timerMap.set(el, timer);
-      };
+  for (const el of elements) {
+    const mouseenterListener = e => {
+      const timer = setTimeout(() => {
+        el.removeEventListener('mouseenter', mouseenterListener);
+        el.removeEventListener('mouseleave', mouseleaveListener);
+        return callback(url, ...args);
+      }, 200);
+      timerMap.set(el, timer);
+    };
 
-      const mouseleaveListener = e => {
-        const timer = timerMap.get(el);
-        if (timer) {
-          clearTimeout(timer);
-          timerMap.delete(el);
-        }
-      };
+    const mouseleaveListener = e => {
+      const timer = timerMap.get(el);
+      if (timer) {
+        clearTimeout(timer);
+        timerMap.delete(el);
+      }
+    };
 
-      el.addEventListener('mouseenter', mouseenterListener);
-      el.addEventListener('mouseleave', mouseleaveListener);
-    }
-  } else {
-    return callback();
+    el.addEventListener('mouseenter', mouseenterListener);
+    el.addEventListener('mouseleave', mouseleaveListener);
   }
 }
 

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -94,7 +94,7 @@ export function viaFetch(url, hasModeCors, hasCredentials, isPriority) {
   //
   // As of 2018, fetch() is high-priority in Chrome
   // and medium-priority in Safari.
-  options = {headers: {accept: '*/*'}};
+  const options = {headers: {accept: '*/*'}};
   if (!hasModeCors) options.mode = 'no-cors';
   if (hasCredentials) options.credentials = 'include';
   isPriority ? options.priority = 'high' : options.priority = 'low';

--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -101,4 +101,44 @@ export function viaFetch(url, hasModeCors, hasCredentials, isPriority) {
   return window.fetch ? fetch(url, options) : viaXHR(url, hasCredentials);
 }
 
+/**
+ * Calls the prefetch function immediately
+ * or only on the mouseover event.
+ * @param {Function} callback  - original prefetch function
+ * @param {String} url - url to prefetch
+ * @param {Boolean} onlyOnMouseover - true to add the mouseover listener
+ * @return {Object} a Promise
+ */
+export function addMouseoverListener(callback, url, onlyOnMouseover) {
+  if (onlyOnMouseover) {
+    const elements = document.querySelectorAll(`a[href="${url}"]`);
+
+    for (const el of elements) {
+      const timerMap = new Map();
+
+      const mouseenterListener = e => {
+        const timer = setTimeout(() => {
+          el.removeEventListener('mouseenter', mouseenterListener);
+          el.removeEventListener('mouseleave', mouseleaveListener);
+          return callback();
+        }, 200);
+        timerMap.set(el, timer);
+      };
+
+      const mouseleaveListener = e => {
+        const timer = timerMap.get(el);
+        if (timer) {
+          clearTimeout(timer);
+          timerMap.delete(el);
+        }
+      };
+
+      el.addEventListener('mouseenter', mouseenterListener);
+      el.addEventListener('mouseleave', mouseleaveListener);
+    }
+  } else {
+    return callback();
+  }
+}
+
 export const supported = hasPrefetch() ? viaDOM : viaFetch;

--- a/src/prerender.mjs
+++ b/src/prerender.mjs
@@ -20,12 +20,15 @@
 /**
  * Add a given set of urls to the speculation rules
  * @param {Set} urlsToPrerender - the URLs to add to speculation rules
+ * @param {String} eagerness - prerender eagerness mode - default immediate
  * @return {Boolean|Object}  boolean or Error Object
  */
-export function addSpeculationRules(urlsToPrerender) {
+export function addSpeculationRules(urlsToPrerender, eagerness = 'immediate') {
   const specScript = document.createElement('script');
   specScript.type = 'speculationrules';
-  specScript.text = `{"prerender":[{"source": "list","urls": ["${Array.from(urlsToPrerender).join('","')}"]}]}`;
+  specScript.text = `{"prerender":[{"source": "list",
+                      "urls": ["${Array.from(urlsToPrerender).join('","')}"],
+                      "eagerness": "${eagerness}"}]}`;
   try {
     document.head.appendChild(specScript);
   } catch (error) {

--- a/src/prerender.mjs
+++ b/src/prerender.mjs
@@ -23,12 +23,10 @@
  * @param {String} eagerness - prerender eagerness mode
  * @return {Boolean|Object}  boolean or Error Object
  */
-export function addSpeculationRules(urlsToPrerender, eagerness) {
+export function addSpeculationRules(urlsToPrerender) {
   const specScript = document.createElement('script');
   specScript.type = 'speculationrules';
-  specScript.text = `{"prerender":[{"source": "list",
-                      "urls": ["${Array.from(urlsToPrerender).join('","')}"],
-                      "eagerness": "${eagerness}"}]}`;
+  specScript.text = `{"prerender":[{"source": "list","urls": ["${Array.from(urlsToPrerender).join('","')}"]}]}`;
   try {
     document.head.appendChild(specScript);
   } catch (error) {

--- a/src/prerender.mjs
+++ b/src/prerender.mjs
@@ -20,10 +20,10 @@
 /**
  * Add a given set of urls to the speculation rules
  * @param {Set} urlsToPrerender - the URLs to add to speculation rules
- * @param {String} eagerness - prerender eagerness mode - default immediate
+ * @param {String} eagerness - prerender eagerness mode
  * @return {Boolean|Object}  boolean or Error Object
  */
-export function addSpeculationRules(urlsToPrerender, eagerness = 'immediate') {
+export function addSpeculationRules(urlsToPrerender, eagerness) {
   const specScript = document.createElement('script');
   specScript.type = 'speculationrules';
   specScript.text = `{"prerender":[{"source": "list",

--- a/test/quicklink.spec.js
+++ b/test/quicklink.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const puppeteer = require('puppeteer');
-const {suite} = require('uvu');
+const { suite } = require('uvu');
 const assert = require('uvu/assert');
 
 const host = 'http://127.0.0.1:8080';
@@ -269,7 +269,7 @@ mainSuite('should respect the `throttle` concurrency', async context => {
     if (/test\/fixtures\/\d+\.html$/i.test(url)) {
       await sleep(100);
       URLs.push(url);
-      return req.respond({status: 200});
+      return req.respond({ status: 200 });
     }
 
     req.continue();

--- a/test/quicklink.spec.js
+++ b/test/quicklink.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const puppeteer = require('puppeteer');
-const { suite } = require('uvu');
+const {suite} = require('uvu');
 const assert = require('uvu/assert');
 
 const host = 'http://127.0.0.1:8080';
@@ -269,7 +269,7 @@ mainSuite('should respect the `throttle` concurrency', async context => {
     if (/test\/fixtures\/\d+\.html$/i.test(url)) {
       await sleep(100);
       URLs.push(url);
-      return req.respond({ status: 200 });
+      return req.respond({status: 200});
     }
 
     req.continue();


### PR DESCRIPTION
Dear @addyosmani @XhmikosR ,

I am submitting this pull request to address issues encountered within our Luxottica e-commerce group, where we observed inconsistent resource prefetching behavior across different browsers.

Currently, three prefetching methods are implemented:

1. **viaDom** – Prefetches resources without checking the `Access-Control-Allow-Origin` header, using the attribute `crossorigin="anonymous"`.
2. **viaXhr** – Fetches resources while always validating the `Access-Control-Allow-Credentials` response header.
3. **viaFetch** – Executes a fetch request that defaults to `mode: "cors"` and checks `Access-Control-Allow-Origin`, while `credentials: "include"` ensures `Access-Control-Allow-Credentials` validation.
Additionally, I have handled resource prioritization for Safari devices, adding the `priority: "low|high"` property specifically for fetch requests. All parameters are set to `false` by default but can be adjusted as needed.

The updated method signature for prefetching is as follows:

```
prefetch(url, isPriority, checkAccessControlAllowOrigin, checkAccessControlAllowCredentials);
```
```
window.addEventListener('load', () => {
  quicklink.listen({el, priority,
                    checkAccessControlAllowOrigin, checkAccessControlAllowCredentials});
});
```

I would appreciate your review of these improvements.

Thank you,
Giorgio

c.c. @gilbertococchi 