### PR TITLE
prefetchOnHover: drop filter after `querySelectorAll`

### DIFF
--- a/src/prefetch.mjs
+++ b/src/prefetch.mjs
@@ -112,7 +112,7 @@ export function viaFetch(url, hasModeCors, hasCredentials, isPriority) {
 export function prefetchOnHover(callback, url, onlyOnMouseover, ...args) {
   if (!onlyOnMouseover) return callback(url, ...args);
 
-  const elements = Array.from(document.querySelectorAll('a')).filter(el => el.href === url);
+  const elements = document.querySelectorAll(`a[href="${url}"]`);
   const timerMap = new Map();
 
   for (const el of elements) {


### PR DESCRIPTION
This should be more efficient