### PR TITLE
index.mjs: fix constant assignment

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -175,11 +175,13 @@ export function listen(options = {}) {
       } else {
         entry = entry.target;
         const index = hrefsInViewport.indexOf(entry.href);
+
         if (index > -1) {
           hrefsInViewport.splice(index);
         }
+
         if (specRulesInViewport.has(entry.href)) {
-          specRulesInViewport = removeSpeculationRule(specRulesInViewport, entry.href);
+          specRulesInViewport.set(removeSpeculationRule(specRulesInViewport, entry.href));
         }
       }
     });


### PR DESCRIPTION
specRulesInViewport is a Map so .set() should be used

This was introduced in #446.

The site docs still need to be updated for #446 and also this makes me wonder why tests didn't catch the error. Maybe they don't cover this part and we need to adapt the tests?

/CC @giorgiopellegrino to take care of the aforementioned issues when you have time.