### PR TITLE
Skip prefetching anchors with the download attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,8 @@ quicklink.listen({
 
 ### Custom Ignore Patterns
 
+By default, quicklink skips anchors that have a [`download`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download) attribute, since those often point at large binary payloads.
+
 These filters run _after_ the `origins` matching has run. Ignores can be useful for avoiding large file downloads or for responding to DOM attributes dynamically.
 
 ```js

--- a/src/chunks.mjs
+++ b/src/chunks.mjs
@@ -106,7 +106,7 @@ export function listen(options = {}) {
   });
 
   timeoutFn(() => {
-    // Find all links & Connect them to IO if allowed.
+    // Find all links & connect them to IO if allowed.
     // Skip anchors with the `download` attribute (large payloads).
     const links = (options.el || document).querySelectorAll('a[href]:not([download])');
     for (const link of links) {

--- a/src/chunks.mjs
+++ b/src/chunks.mjs
@@ -106,8 +106,9 @@ export function listen(options = {}) {
   });
 
   timeoutFn(() => {
-    // Find all links & Connect them to IO if allowed
-    const links = (options.el || document).querySelectorAll('a[href]');
+    // Find all links & Connect them to IO if allowed.
+    // Skip anchors with the `download` attribute (large payloads).
+    const links = (options.el || document).querySelectorAll('a[href]:not([download])');
     for (const link of links) {
       // If the anchor matches a permitted origin
       // ~> A `[]` or `true` means everything is allowed

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -206,11 +206,15 @@ export function listen(options = {}) {
   });
 
   timeoutFn(() => {
-    // Find all links & Connect them to IO if allowed
+    // Find all links & Connect them to IO if allowed.
+    // Skip anchors with the `download` attribute — those often point at large
+    // binary payloads that are wasteful to prefetch.
     const isAnchorElement = options.el && options.el.length > 0 && options.el[0].nodeName === 'A';
-    const elementsToListen = isAnchorElement ? options.el : (options.el || document).querySelectorAll('a');
+    const elementsToListen = isAnchorElement ? options.el : (options.el || document).querySelectorAll('a:not([download])');
 
     for (const link of elementsToListen) {
+      // NodeList of anchors may still include download links
+      if (link.hasAttribute('download')) continue;
       // If the anchor matches a permitted origin
       // ~> A `[]` or `true` means everything is allowed
       if (!allowed.length || allowed.includes(link.hostname)) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -206,8 +206,8 @@ export function listen(options = {}) {
   });
 
   timeoutFn(() => {
-    // Find all links & Connect them to IO if allowed.
-    // Skip anchors with the `download` attribute — those often point at large
+    // Find all links & connect them to IO if allowed.
+    // Skip anchors with the `download` attribute - those often point at large
     // binary payloads that are wasteful to prefetch.
     const isAnchorElement = options.el && options.el.length > 0 && options.el[0].nodeName === 'A';
     const elementsToListen = isAnchorElement ? options.el : (options.el || document).querySelectorAll('a:not([download])');

--- a/test/fixtures/test-ignore-download.html
+++ b/test/fixtures/test-ignore-download.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Prefetch: Ignore download attribute</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="main.css">
+</head>
+
+<body>
+  <a href="1.html">Link 1</a>
+  <a href="2.html" download>Download Link 2</a>
+  <a href="3.html" download="report.pdf">Download Link 3</a>
+  <a href="4.html" style="position:absolute;margin-top:900px;">Link 4</a>
+  <script src="../../dist/quicklink.umd.js"></script>
+  <script>
+    quicklink.listen();
+  </script>
+</body>
+
+</html>

--- a/test/quicklink.spec.js
+++ b/test/quicklink.spec.js
@@ -207,6 +207,24 @@ mainSuite('should only prefetch links after ignore patterns allowed it', async c
   assert.not.ok(responseURLs.includes('https://github.githubassets.com/images/spinners/octocat-spinner-32.gif'));
 });
 
+mainSuite('should not prefetch links with the download attribute', async context => {
+  const responseURLs = [];
+  context.page.on('response', resp => {
+    responseURLs.push(resp.url());
+  });
+  await context.page.goto(`${server}/test-ignore-download.html`);
+  await sleep();
+  assert.instance(responseURLs, Array);
+
+  assert.ok(responseURLs.includes(`${server}/1.html`));
+  // boolean download attribute
+  assert.not.ok(responseURLs.includes(`${server}/2.html`));
+  // download="filename" attribute
+  assert.not.ok(responseURLs.includes(`${server}/3.html`));
+  // out of viewport
+  assert.not.ok(responseURLs.includes(`${server}/4.html`));
+});
+
 mainSuite('should only prefetch links after ignore patterns allowed it (multiple)', async context => {
   const responseURLs = [];
   context.page.on('response', resp => {


### PR DESCRIPTION
## Summary
- Do not observe / prefetch `<a download>` links by default (boolean or named `download` attribute)
- Applies in both `listen` (`src/index.mjs`) and the chunks path (`src/chunks.mjs`)
- Adds a fixture + puppeteer test and a short README note under Custom Ignore Patterns

Fixes #181

## Why this matters
Download links often target large binaries (PDFs, archives, exports). Prefetching them wastes bandwidth and cache space on paths the user may never follow — especially on metered or Save-Data connections where quicklink already throttles prefetch. Treating `download` like other built-in ignore patterns (external origins, `rel=nofollow`, etc.) keeps prefetch focused on navigational routes.

## Test plan
- [x] `npm test` (19/19 passing)
- [x] `npm run size` (within limits)
- [x] `npm run lint`
- [x] Confirm CLA check passes for @sankalpsthakur