### PR TITLE
site: fix redirects and broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Quicklink attempts to make navigations to subsequent pages load faster. It:
 - **Detects links within the viewport** (using [Intersection Observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API))
 - **Waits until the browser is idle** (using [requestIdleCallback](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback))
 - **Checks if the user isn't on a slow connection** (using `navigator.connection.effectiveType`) or has data-saver enabled (using `navigator.connection.saveData`)
-- **Prefetches** (using [`<link rel=prefetch>`](https://www.w3.org/TR/resource-hints/#prefetch) or XHR) or **prerenders** (using [Speculation Rules API](https://github.com/WICG/nav-speculation/blob/main/triggers.md)) URLs to the links. Provides some control over the request priority (can switch to `fetch()` if supported).
+- **Prefetches** (using [`<link rel=prefetch>`](https://html.spec.whatwg.org/multipage/links.html#link-type-prefetch) or XHR) or **prerenders** (using [Speculation Rules API](https://github.com/WICG/nav-speculation/blob/main/triggers.md)) URLs to the links. Provides some control over the request priority (can switch to `fetch()` if supported).
 
 ## Why
 
@@ -293,7 +293,7 @@ Returns: `Promise`
 
 One or many URLs to be prerendered.
 
-> **Note:** Speculative Rules API supports same-site cross origin Prerendering with [opt-in header](https://bit.ly/ss-cross-origin-pre).
+> **Note:** Speculative Rules API supports same-site cross origin Prerendering with [opt-in header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Supports-Loading-Mode).
 
 #### eagerness
 
@@ -403,7 +403,7 @@ quicklink.listen({
 
 Enables all cross-origin requests to be made.
 
-> **Note:** You may run into [CORB](https://chromium.googlesource.com/chromium/src/+/main/services/network/cross_origin_read_blocking_explainer.md) and [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) issues!
+> **Note:** You may run into [CORB](https://chromium.googlesource.com/chromium/src/+/main/services/network/cross_origin_read_blocking_explainer.md) and [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS) issues!
 
 ```js
 quicklink.listen({
@@ -538,7 +538,7 @@ Ads appear on sites mostly in two ways:
 - Want a more data-driven approach? See [Guess.js](https://guess-js.github.io). It uses analytics and machine-learning to prefetch resources based on how users navigate your site. It also has plugins for [Webpack](https://www.npmjs.com/package/guess-webpack) and [Gatsby](https://www.gatsbyjs.org/docs/optimizing-site-performance-with-guessjs/).
 - WordPress users can now get quicklink as a [WordPress Plugin from the plugin repository](https://wordpress.org/plugins/quicklink/).
 - Drupal users can install the [Quicklink Drupal module](https://www.drupal.org/project/quicklink).
-- Magento 2 users can install the [rafaelcg-magento2-quicklink](https://marketplace.magento.com/rafaelcg-magento2-quicklink.html) or [rangerz/magento2-module-quicklink](https://github.com/rangerz/magento2-module-quicklink).
+- Magento 2 users can install the [rangerz/magento2-module-quicklink](https://github.com/rangerz/magento2-module-quicklink) module.
 - Want less aggressive prefetching? [instant.page](https://instant.page/) prefetches on mouseover and touchstart, right before a click.
 
 ## License

--- a/site/src/_data/site.js
+++ b/site/src/_data/site.js
@@ -35,12 +35,12 @@ module.exports = () => {
       {
         title: 'magento',
         logoFileName: 'magento.svg',
-        url: 'https://marketplace.magento.com/rafaelcg-magento2-quicklink.html',
+        url: 'https://github.com/rangerz/magento2-module-quicklink',
       },
       {
         title: 'react',
         logoFileName: 'react.svg',
-        url: 'https://github.com/HOUCe/react-quicklink-component/',
+        url: 'https://web.dev/articles/quicklink',
       },
       {
         title: 'angular',
@@ -50,7 +50,7 @@ module.exports = () => {
       {
         title: 'vue',
         logoFileName: 'vue.svg',
-        url: 'https://nuxtjs.org/api/components-nuxt-link/',
+        url: 'https://nuxt.com/docs/api/components/nuxt-link',
       },
     ],
     trustedByLogos: [
@@ -100,12 +100,12 @@ module.exports = () => {
         companyName: 'MATSUDA',
       },
       {
-        websiteUrl: 'https://paulrand.design/',
+        websiteUrl: 'https://www.paulrand.design/',
         logoFileName: 'paulrand.design.png',
         companyName: 'Paul Rand',
       },
       {
-        websiteUrl: 'http://www.week.co.jp/',
+        websiteUrl: 'https://www.week.co.jp/',
         logoFileName: 'week.co.jp.png',
         companyName: 'Komachi',
       },

--- a/site/src/_includes/components/chrome-extension.njk
+++ b/site/src/_includes/components/chrome-extension.njk
@@ -1,11 +1,11 @@
 {% extends "layouts/normal-section-wrapper.njk" %}
 {% block section %}
 {% sectionTitle "Chrome Extension" %}
-{{ "We've developed a [Chrome extension](https://chrome.google.com/webstore/detail/quicklink-chrome-extensio/epmplkdcjhgigmnjmjibilpmekhgkbeg) that injects and initializes `Quicklink` in every site you visit." | markdown | safe }}
+{{ "We've developed a [Chrome extension](https://chromewebstore.google.com/detail/quicklink-chrome-extensio/epmplkdcjhgigmnjmjibilpmekhgkbeg) that injects and initializes `Quicklink` in every site you visit." | markdown | safe }}
 {{ "The extension can be used with the following purposes:" | markdown | safe }}
 
 {{ "* To navigate the web faster." | markdown | safe }}
-{{ "* To estimate the potential impact of `Quicklink` on a site, before implementing it (see [impact measurement guide](/measure))." | markdown | safe }}
+{{ "* To estimate the potential impact of `Quicklink` on a site, before implementing it (see [impact measurement guide](/measure/))." | markdown | safe }}
 
 {{ "The extension comes with a default set of URL patterns [to ignore](https://github.com/GoogleChromeLabs/quicklink#optionsignores) (e.g. signin, logout, etc). You can add more patterns, by clicking on the extension icon, and picking 'Options' from the drop-down menu." | markdown | safe }}
 {{ "The code of the extension can be found at [this repository](https://github.com/demianrenzulli/quicklink-chrome-extension). Contributions are welcomed!" | markdown | safe }}

--- a/site/src/api.njk
+++ b/site/src/api.njk
@@ -191,7 +191,7 @@ Returns: `Promise`
 
 One or many URLs to be prerendered.
 
-> **Note:** Speculative Rules API supports same-site cross origin Prerendering with [opt-in header](https://bit.ly/ss-cross-origin-pre).
+> **Note:** Speculative Rules API supports same-site cross origin Prerendering with [opt-in header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Supports-Loading-Mode).
 
 #### eagerness
 
@@ -306,7 +306,7 @@ quicklink.listen({
 
 Enables all cross-origin requests to be made.
 
-> **Note:** You may run into [CORB](https://chromium.googlesource.com/chromium/src/+/main/services/network/cross_origin_read_blocking_explainer.md) and [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) issues!
+> **Note:** You may run into [CORB](https://chromium.googlesource.com/chromium/src/+/main/services/network/cross_origin_read_blocking_explainer.md) and [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS) issues!
 
 {% endmarkdownConvert %}
 {% highlight "js" %}

--- a/site/src/approach.njk
+++ b/site/src/approach.njk
@@ -26,7 +26,7 @@ Quicklink attempts to make navigations to subsequent pages load faster. It:
 * **Detects links within the viewport** (using [Intersection Observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API))
 * **Waits until the browser is idle** (using [requestIdleCallback](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback))
 * **Checks if the user isn't on a slow connection** (using `navigator.connection.effectiveType`) or has data-saver enabled (using `navigator.connection.saveData`)
-* **Prefetches URLs to the links** (using [`<link rel=prefetch>`](https://www.w3.org/TR/resource-hints/#prefetch) or XHR). Provides some control over the request priority (can switch to `fetch()` if supported).
+* **Prefetches URLs to the links** (using [`<link rel=prefetch>`](https://html.spec.whatwg.org/multipage/links.html#link-type-prefetch) or XHR). Provides some control over the request priority (can switch to `fetch()` if supported).
 
 {% endmarkdownConvert %}
 <img loading="lazy" class="article-image" src="/assets/images/graphs/prefetch-quicklink-svgomg.svg" width="932" height="397" alt="Image shows page load times comparison with and without Quicklink prefetching, showing faster performance when prefetch is enabled">

--- a/site/src/demo.njk
+++ b/site/src/demo.njk
@@ -83,7 +83,7 @@ Here is a comparison video:
 
 ### Single Page Apps
 
-Quicklink 2.0 includes support for React-based single-page-apps. This has been covered to the detail in this [guide](https://web.dev/quicklink/).
+Quicklink 2.0 includes support for React-based single-page-apps. This has been covered to the detail in this [guide](https://web.dev/articles/quicklink).
 
 To try the demo:
 

--- a/site/src/demos/spa/routes/contact.js
+++ b/site/src/demos/spa/routes/contact.js
@@ -9,7 +9,7 @@ export default function render(view) {
     </article>
     <article>
       <h2>Documentation</h2>
-      <p>The <a href="/api">API reference</a>, <a href="/approach">approach</a>, and <a href="/measure">measurement</a> guides cover everything from installation to RUM measurement.</p>
+      <p>The <a href="/api/">API reference</a>, <a href="/approach/">approach</a>, and <a href="/measure/">measurement</a> guides cover everything from installation to RUM measurement.</p>
     </article>
     <p class="callout">This contact route is a separate JS chunk - note in the Network panel that it was prefetched by <code>quicklink</code> while you were on the home or blog route.</p>
   `;

--- a/site/src/measure.njk
+++ b/site/src/measure.njk
@@ -13,7 +13,7 @@ eleventyNavigation:
 ## Measuring impact of Quicklink in sites
 
 Implementing Quicklink in sites can speed up navigations, by automatically prefetching in-viewport links during idle time.
-Different metrics can be improved as a result of this, the most common ones being [Start Render](https://sites.google.com/a/webpagetest.org/docs/using-webpagetest/quick-start-quide#TOC-Start-Render:) and [First Contentful Paint](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint).
+Different metrics can be improved as a result of this, the most common ones being [Start Render](https://sites.google.com/a/webpagetest.org/docs/using-webpagetest/quick-start-quide#TOC-Start-Render:) and [First Contentful Paint](https://developer.chrome.com/docs/lighthouse/performance/first-contentful-paint).
 
 In this section, we explore different ways of measuring the impact of Quicklink in sites. To showcase that, we’ll use the following sites:
 - An [unoptimized e-commerce demo](/demos/mini-ecomm/), consisting of a listing and product pages. The site uses Quicklink-free vanilla HTML, so each navigation hits the network. The source lives in [`site/src/demos/mini-ecomm`](https://github.com/GoogleChromeLabs/quicklink/tree/main/site/src/demos/mini-ecomm).
@@ -32,7 +32,7 @@ If you take a look at the code of the listing page, in the optimized version of 
 {% markdownConvert %}
 ## Using Chrome DevTools
 
-The first tool you’ll use is [Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools), which is useful both for local development, and also for production URLs.
+The first tool you’ll use is [Chrome DevTools](https://developer.chrome.com/docs/devtools/), which is useful both for local development, and also for production URLs.
 
 First, measure performance before implementing Quicklink:
 
@@ -153,23 +153,23 @@ A video can be generated from the [comparison page](https://www.webpagetest.org/
 
 ### Using RUM (Real user monitoring) tools
 
-RUM tools, let you visualize how different metrics evolve in time for real users. If prefetching affects a large amount of pages, you might be able to see more page loads being loaded faster after implementing it, which can be reflected in metrics [First Contentful Paint](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint).
+RUM tools, let you visualize how different metrics evolve in time for real users. If prefetching affects a large amount of pages, you might be able to see more page loads being loaded faster after implementing it, which can be reflected in metrics [First Contentful Paint](https://developer.chrome.com/docs/lighthouse/performance/first-contentful-paint).
 
-For example, the [Chrome User Experience Report](https://developers.google.com/web/tools/chrome-user-experience-report/) provides performance metrics for how real-world Chrome users experience popular destinations on the web.
-CrUX data is available in [PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/) and also in [BigQuery](https://bigquery.cloud.google.com/dataset/chrome-ux-report:all?pli=1), but you can obtain a quick visualization of the evolution of your metrics using the [CrUX dashboard](https://g.co/chromeuxdash) (refer to [this guide](https://web.dev/chrome-ux-report-data-studio-dashboard/) for more details).
+For example, the [Chrome User Experience Report](https://developer.chrome.com/docs/crux/) provides performance metrics for how real-world Chrome users experience popular destinations on the web.
+CrUX data is available in [PageSpeed Insights](https://pagespeed.web.dev/) and also in [BigQuery](https://developer.chrome.com/docs/crux/bigquery/), but you can obtain a quick visualization of the evolution of your metrics using the [CrUX dashboard](https://g.co/chromeuxdash) (refer to [this guide](https://developer.chrome.com/docs/crux/guides/looker-studio-dashboard) for more details).
 The report contains a section for First Contentful Paint. If a large number of page views are prefetched as a result of implementing Quicklink, this graph could show a positive evolution in time.
 
 **Note:** Even when checking the performance for real users is a general performance best practice, it’s usually hard to correlate the overall performance improvement of a site with a single optimization like this one. With that said, the best way to make sure you’re measuring exactly this change is to perform a before / after test with laboratory tools as explained in previous sections.
 
 ### Using Quicklink Chrome extension
 
-[Quicklink Chrome Extension](https://chrome.google.com/webstore/detail/quicklink-chrome-extensio/epmplkdcjhgigmnjmjibilpmekhgkbeg) injects Quicklink in every site a user visits. You can use it to measure the potential impact of implementing the library on a site, before doing it.
+[Quicklink Chrome Extension](https://chromewebstore.google.com/detail/quicklink-chrome-extensio/epmplkdcjhgigmnjmjibilpmekhgkbeg) injects Quicklink in every site a user visits. You can use it to measure the potential impact of implementing the library on a site, before doing it.
 Since the extension will simulate how the library would work when implemented, you can install the extension and then run the tests with DevTools, as described in the previous section.
 
 ### Conclusion
 
 Quicklink can highly improve navigations by automatically prefetching in-viewport links, . We’ve explored different tools to measure the impact of implementing it in your site.
-Metrics like [Start Render](https://sites.google.com/a/webpagetest.org/docs/using-webpagetest/quick-start-quide#TOC-Start-Render:) and [First Contentful Paint](https://developers.google.com/web/tools/lighthouse/audits/first-contentful-paint) can be directly impacted by this change, but other metrics can be also improved as a result of this, as seen in the tests performed in this guide.
+Metrics like [Start Render](https://sites.google.com/a/webpagetest.org/docs/using-webpagetest/quick-start-quide#TOC-Start-Render:) and [First Contentful Paint](https://developer.chrome.com/docs/lighthouse/performance/first-contentful-paint) can be directly impacted by this change, but other metrics can be also improved as a result of this, as seen in the tests performed in this guide.
 Laboratory testing tools, like Chrome DevTools and Webpagetest can help you have an accurate idea of the impact of this change, by running a before / after comparison. Also, If the number of pages affected by this change is large enough, you might be able to visualize the impact of the implementation on real user monitoring (RUM) tools as well.
 
 {% endmarkdownConvert %}

--- a/translations/zh-cn/README.md
+++ b/translations/zh-cn/README.md
@@ -23,7 +23,7 @@ Quicklink 通过以下方式加快后续页面的加载速度：
 - **检测视区中的链接**（使用 [Intersection Observer](https://developer.mozilla.org/zh-CN/docs/Web/API/Intersection_Observer_API)）。
 - **等待浏览器空闲**（使用 [requestIdleCallback](https://developer.mozilla.org/zh-CN/docs/Web/API/Window/requestIdleCallback)）。
 - **确认用户并未处于慢速连接**（使用 `navigator.connection.effectiveType`）或启用省流模式（使用 `navigator.connection.saveData`）。
-- **预获取视区内的 URL**（使用 [`<link rel=prefetch>`](https://www.w3.org/TR/resource-hints/#prefetch) 或 XHR）。可根据请求优先级进行控制（若支持 fetch() 可进行切换）。
+- **预获取视区内的 URL**（使用 [`<link rel=prefetch>`](https://html.spec.whatwg.org/multipage/links.html#link-type-prefetch) 或 XHR）。可根据请求优先级进行控制（若支持 fetch() 可进行切换）。
 
 ## 开发原因
 
@@ -166,7 +166,7 @@ quicklink({
 
 允许所有跨域请求。
 
-> **注意**：可能会导致 [CORB](https://chromium.googlesource.com/chromium/src/+/main/services/network/cross_origin_read_blocking_explainer.md) 以及 [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) 问题！
+> **注意**：可能会导致 [CORB](https://chromium.googlesource.com/chromium/src/+/main/services/network/cross_origin_read_blocking_explainer.md) 以及 [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS) 问题！
 
 ```js
 quicklink({


### PR DESCRIPTION
Only the `sites.google.com` and `docs.webpagetest.org` are left. Not sure how to proceed with those... There are some other weird ones like `g.co/chromeuxdash`.