### PR TITLE
fix(readme): point demo link at getquick.link/demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ The source for these demos lives under [`site/src/demos/`](https://github.com/Go
 
 ### Research
 
-Here's a [WebPageTest run](https://www.webpagetest.org/video/view.php?id=181212_4c294265117680f2636676721cc886613fe2eede&data=1) for our [demo](https://keyword-2-ecd7b.firebaseapp.com/) improving page-load performance by up to 4 seconds via quicklink's prefetching. A [video](https://youtu.be/rQ75YEbJicw) comparison of the before/after prefetching is on YouTube.
+Here's a [WebPageTest run](https://www.webpagetest.org/video/view.php?id=181212_4c294265117680f2636676721cc886613fe2eede&data=1) for our [demo](https://getquick.link/demo/) improving page-load performance by up to 4 seconds via quicklink's prefetching. A [video](https://youtu.be/rQ75YEbJicw) comparison of the before/after prefetching is on YouTube.
 
 For demo purposes, we deployed a version of the [Google Blog](https://blog.google) on
 Firebase hosting. We then deployed another version of it, adding quicklink to the homepage and benchmarked navigating from the homepage to an article that was


### PR DESCRIPTION
Fixes #204

Single URL change in README: Research demo link now points at https://getquick.link/demo/.